### PR TITLE
Step04. 실행 및 API명세서 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# hh-08-concert
+# 콘서트 예약 서비스
+
+
+## 1. 마일스톤 
+
+👉[Github Project Milestone](https://github.com/users/loveAlakazam/projects/9/views/8)
+
+
+## 2. 시퀀스 다이어그램
+
+👉[시퀀스 다이어그램 wiki](https://github.com/loveAlakazam/hh-08-concert/wiki/03_%EC%8B%9C%ED%80%80%EC%8A%A4%EB%8B%A4%EC%9D%B4%EC%96%B4%EA%B7%B8%EB%9E%A8)
+
+## 3. ERD 다이어그램
+
+![ERD Diagram](https://github.com/loveAlakazam/hh-08-concert/wiki/images/erd-ver-1.png)
+
+## 4. API 명세서
+
+👉[API Swagger]()
+

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// Swagger UI
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	// Swagger UI
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/io/hhplus/concert/application/usecase/concert/usecase/ConcertUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/concert/usecase/ConcertUsecase.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.application.usecase.concert.usecase;
+
+public class ConcertUsecase {
+}

--- a/src/main/java/io/hhplus/concert/application/usecase/payment/usecase/PaymentUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/payment/usecase/PaymentUsecase.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.application.usecase.payment.usecase;
+
+public class PaymentUsecase {
+}

--- a/src/main/java/io/hhplus/concert/application/usecase/reservation/usecase/ResservationUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/reservation/usecase/ResservationUsecase.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.application.usecase.reservation.usecase;
+
+public class ResservationUsecase {
+}

--- a/src/main/java/io/hhplus/concert/application/usecase/token/usecase/TokenUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/token/usecase/TokenUsecase.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.application.usecase.token.usecase;
+
+public class TokenUsecase {
+}

--- a/src/main/java/io/hhplus/concert/domain/common/entity/BaseEntity.java
+++ b/src/main/java/io/hhplus/concert/domain/common/entity/BaseEntity.java
@@ -1,9 +1,12 @@
 package io.hhplus.concert.domain.common.entity;
 
+import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+
 import java.time.LocalDateTime;
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import io.hhplus.concert.domain.common.exceptions.InvalidValidationException;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -18,4 +21,8 @@ public class BaseEntity {
 
 	@Column(name="updated_at")
 	private LocalDateTime updatedAt;
+
+	public static void validateId(long id) {
+		if(id <= 0 ) throw new InvalidValidationException(ID_SHOULD_BE_POSITIVE_NUMBER);
+	}
 }

--- a/src/main/java/io/hhplus/concert/domain/common/entity/BaseEntity.java
+++ b/src/main/java/io/hhplus/concert/domain/common/entity/BaseEntity.java
@@ -1,0 +1,21 @@
+package io.hhplus.concert.domain.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+	@Column(name="created_at")
+	private LocalDateTime createdAt;
+
+	@Column(name="updated_at")
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/io/hhplus/concert/domain/common/exceptions/CommonExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/common/exceptions/CommonExceptionMessage.java
@@ -2,4 +2,5 @@ package io.hhplus.concert.domain.common.exceptions;
 
 public interface CommonExceptionMessage {
 	String ID_SHOULD_BE_POSITIVE_NUMBER = "식별자 아이디는 0보다 큰 양수여야 합니다.";
+	String INTERNAL_SERVER_ERROR = "서버 내부에서 발생한 오류입니다.";
 }

--- a/src/main/java/io/hhplus/concert/domain/common/exceptions/CommonExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/common/exceptions/CommonExceptionMessage.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.domain.common.exceptions;
+
+public interface CommonExceptionMessage {
+	String ID_SHOULD_BE_POSITIVE_NUMBER = "식별자 아이디는 0보다 큰 양수여야 합니다.";
+}

--- a/src/main/java/io/hhplus/concert/domain/common/exceptions/InvalidValidationException.java
+++ b/src/main/java/io/hhplus/concert/domain/common/exceptions/InvalidValidationException.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.domain.common.exceptions;
+
+// 유효성검사 실패할 때 발생하는 예외
+public class InvalidValidationException extends IllegalArgumentException {
+	public InvalidValidationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/entity/Concert.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/entity/Concert.java
@@ -1,0 +1,40 @@
+package io.hhplus.concert.domain.concert.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.reservation.entity.Reservation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Table(name ="concerts")
+@RequiredArgsConstructor
+public class Concert extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id; // 콘서트 PK
+
+	@Column(nullable = false)
+	private String name; // 콘서트명
+
+	// 연관관계
+	@OneToMany(mappedBy = "concert")
+	private List<ConcertDate> dates = new ArrayList<>(); // 콘서트:날짜=1:N
+	@OneToMany(mappedBy = "concert")
+	private List<Seat> seats = new ArrayList<>(); // 콘서트:좌석=1:N
+	@OneToOne
+	@JoinColumn(name="reservation_id")
+	private Reservation reservation; // 콘서트:예약=1:1
+
+	// 비즈니스 책임
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/entity/ConcertDate.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/entity/ConcertDate.java
@@ -1,0 +1,43 @@
+package io.hhplus.concert.domain.concert.entity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.reservation.entity.Reservation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Table(name ="concert_dates")
+@RequiredArgsConstructor
+public class ConcertDate extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id; // 날짜 PK
+
+	@Column(nullable = false)
+	private LocalDate startDate; // 공연시작날짜
+
+	// 연관관계
+	@ManyToOne
+	@JoinColumn(name="concert_id")
+	private Concert concert; // 콘서트:날짜=1:N
+	@OneToMany(mappedBy = "date")
+	private List<Seat> seats = new ArrayList<>(); // 날짜:좌석=1:N
+	@OneToOne
+	@JoinColumn(name="reservation_id")
+	private Reservation reservation;// 예약:날짜=1:1
+
+	// 비즈니스 책임
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/entity/Seat.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/entity/Seat.java
@@ -1,0 +1,60 @@
+package io.hhplus.concert.domain.concert.entity;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.reservation.entity.Reservation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "seats")
+@RequiredArgsConstructor
+public class Seat extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id; // 좌석 PK
+
+	@Column(nullable = false)
+	private int number; // 좌석번호(1~50)
+
+	@Column(nullable = false)
+	private long price; // 좌석가격
+
+	@Column(name="is_available")
+	private boolean isAvailable; // 예약가능여부
+
+	// 연관관계
+	@ManyToOne
+	@JoinColumn(name="concert_id")
+	private Concert concert; // 콘서트:좌석=1:N
+	@ManyToOne
+	@JoinColumn(name="date_id")
+	private ConcertDate date;// 날짜:좌석=1:N
+	@OneToOne
+	@JoinColumn(name="reservation_id")
+	private Reservation reservation; // 예약:좌석=1:1
+
+	// 비즈니스 책임
+	// 비즈니스 정책
+	public static final int MIN_SEAT_NUMBER=1;
+	public static final int MAX_SEAT_NUMBER=50;
+
+	// 좌석 예약가능여부 변경
+	public void updateOppositeIsAvailable() {
+		// 임시예약 성공했을 때, 예약가능여부를 "예약가능(true)" -> "예약불가능(false)"로 변경
+		// 임시예약 기간이 만료되어 취소됐을 때, 예약가능여부를 "예약불가능(false)" -> "예약가능(true)" 으로 변경
+		this.isAvailable = !this.isAvailable;
+	}
+
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/exceptions/messages/ConcertExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/exceptions/messages/ConcertExceptionMessage.java
@@ -1,0 +1,9 @@
+package io.hhplus.concert.domain.concert.exceptions.messages;
+
+import io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage;
+
+public interface ConcertExceptionMessage extends CommonExceptionMessage {
+	String AVAILABLE_SEAT_NOT_FOUND = "예약가능한 좌석이 존재하지 않습니다.";
+	String ALL_SEAT_RESERVED= "모든 좌석이 예약되었습니다.";
+	String TEMPORARY_RESERVED_TIMEOUT="임시예약된 좌석의 유효시간이 만료되었습니다.";
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/repository/ConcertDateRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/repository/ConcertDateRepository.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.domain.concert.repository;
+
+public interface ConcertDateRepository {
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/repository/ConcertRepository.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.domain.concert.repository;
+
+public interface ConcertRepository {
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/repository/SeatRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/repository/SeatRepository.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.domain.concert.repository;
+
+public interface SeatRepository {
+}

--- a/src/main/java/io/hhplus/concert/domain/concert/service/ConcertService.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/service/ConcertService.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.domain.concert.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConcertService {
+}

--- a/src/main/java/io/hhplus/concert/domain/payment/entity/Payment.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/entity/Payment.java
@@ -1,0 +1,34 @@
+package io.hhplus.concert.domain.payment.entity;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.concert.entity.ConcertDate;
+import io.hhplus.concert.domain.reservation.entity.Reservation;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "payments")
+@RequiredArgsConstructor
+public class Payment extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id; // 결제 PK
+
+	// 연관관계
+	@OneToOne
+	@JoinColumn(name="reservation_id")
+	private Reservation reservation; // 결제:예약=1:1
+
+	// 비즈니스 책임
+	// 비즈니스 정책
+}

--- a/src/main/java/io/hhplus/concert/domain/payment/exceptions/messages/PaymentExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/exceptions/messages/PaymentExceptionMessage.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.domain.payment.exceptions.messages;
+
+import io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage;
+
+public interface PaymentExceptionMessage extends CommonExceptionMessage {
+	String FAILED_PAYMENT= "해당 좌석 결제가 실패했습니다.";
+}

--- a/src/main/java/io/hhplus/concert/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.domain.payment.repository;
+
+public interface PaymentRepository {
+}

--- a/src/main/java/io/hhplus/concert/domain/payment/service/PaymentService.java
+++ b/src/main/java/io/hhplus/concert/domain/payment/service/PaymentService.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.domain.payment.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentService {
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/entity/Reservation.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/entity/Reservation.java
@@ -1,0 +1,55 @@
+package io.hhplus.concert.domain.reservation.entity;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.concert.entity.Concert;
+import io.hhplus.concert.domain.concert.entity.ConcertDate;
+import io.hhplus.concert.domain.concert.entity.Seat;
+import io.hhplus.concert.domain.payment.entity.Payment;
+import io.hhplus.concert.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "reservations")
+@RequiredArgsConstructor
+public class Reservation extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id; // 예약 PK
+
+	@Enumerated(EnumType.STRING)
+	private ReservationStatus status;
+
+	// 연관관계
+	@ManyToOne
+	@JoinColumn(name="user_id")
+	private User user; // 유저:예약=1:N
+	@OneToOne
+	@JoinColumn(name="concert_id")
+	private Concert concert; // 콘서트:예약=1:1
+	@OneToOne
+	@JoinColumn(name="date_id")
+	private ConcertDate date; // 날짜:예약=1:1
+	@OneToOne
+	@JoinColumn(name="seat_id")
+	private Seat seat; // 좌석:예약=1:1
+	@OneToOne
+	@JoinColumn(name="payment_id")
+	private Payment payment; // 결제:예약=1:1
+
+
+	// 비즈니스 책임
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/entity/ReservationStatus.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/entity/ReservationStatus.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.domain.reservation.entity;
+
+public enum ReservationStatus {
+	PENDING_PAYMENT,
+	CONFIRMED,
+	CANCELED
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/exceptions/messages/ReservationExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/exceptions/messages/ReservationExceptionMessage.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.domain.reservation.exceptions.messages;
+
+import io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage;
+
+public interface ReservationExceptionMessage extends CommonExceptionMessage {
+	String ALREADY_RESERVED = "해당 좌석은 이미 예약되었습니다.";
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.domain.reservation.repository;
+
+public interface ReservationRepository {
+}

--- a/src/main/java/io/hhplus/concert/domain/reservation/service/ReservationService.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/service/ReservationService.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.domain.reservation.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReservationService {
+}

--- a/src/main/java/io/hhplus/concert/domain/token/service/TokenService.java
+++ b/src/main/java/io/hhplus/concert/domain/token/service/TokenService.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.domain.token.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenService {
+}

--- a/src/main/java/io/hhplus/concert/domain/token/service/exception/messages/TokenExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/token/service/exception/messages/TokenExceptionMessage.java
@@ -1,0 +1,9 @@
+package io.hhplus.concert.domain.token.service.exception.messages;
+
+import io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage;
+
+public interface TokenExceptionMessage extends CommonExceptionMessage {
+
+	String ALLOW_ACTIVE_TOKEN="활성화되지 않은 토큰 입니다.";
+	String EXPIRED_OR_UNAVAILABLE_TOKEN="만료되거나 유효하지 않은 토큰입니다.";
+}

--- a/src/main/java/io/hhplus/concert/domain/user/entity/User.java
+++ b/src/main/java/io/hhplus/concert/domain/user/entity/User.java
@@ -1,0 +1,69 @@
+package io.hhplus.concert.domain.user.entity;
+
+import static io.hhplus.concert.domain.user.exceptions.messages.UserExceptionMessage.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.common.exceptions.InvalidValidationException;
+import io.hhplus.concert.domain.reservation.entity.Reservation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+
+@Entity
+@Table(name = "users")
+@RequiredArgsConstructor
+public class User extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id; // 유저 PK
+
+	@Column(nullable = false)
+	private String name; // 유저명
+
+	@Column(nullable = false)
+	private long point; // 유저 보유포인트
+
+	// 연관관계
+	@OneToMany(mappedBy = "user")
+	private List<Reservation> reservations = new ArrayList<>(); // 유저:예약=1:N
+
+	// 비즈니스 책임
+	// 비즈니스 정책
+	public final static long CHARGE_POINT_MINIMUM = 1000;
+	public final static long CHARGE_POINT_MAXIMUM = 100000;
+	/**
+	 * chargePoint: 포인트 충전
+	 * @param amount long : 충전금액
+	 */
+	public long chargePoint(long amount) {
+		if(amount <= 0) throw new InvalidValidationException(AMOUNT_SHOULD_BE_POSITIVE_NUMBER);
+		if(amount < CHARGE_POINT_MINIMUM) throw new InvalidValidationException(CHARGE_AMOUNT_SHOULD_BE_MORE_THAN_MINIMUM);
+		if(amount > CHARGE_POINT_MAXIMUM) throw new InvalidValidationException(CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM);
+
+		this.point = this.point + amount; // 포인트 계산
+		return this.point; // 계산후 포인트를 반환
+	}
+	/**
+	 * usePoint: 포인트 사용
+	 * @param amount long : 사용금액
+	 */
+	public long usePoint(long amount) {
+		if(amount <= 0) throw new InvalidValidationException(AMOUNT_SHOULD_BE_POSITIVE_NUMBER);
+		if(this.point < amount) throw new InvalidValidationException(LACK_OF_YOUR_POINT);
+
+		this.point = this.point - amount; // 포인트 차감
+		return this.point; // 계산후 포인트를 반환
+	}
+
+}

--- a/src/main/java/io/hhplus/concert/domain/user/entity/User.java
+++ b/src/main/java/io/hhplus/concert/domain/user/entity/User.java
@@ -21,6 +21,7 @@ import lombok.Setter;
 
 
 @Entity
+@Getter
 @Table(name = "users")
 @RequiredArgsConstructor
 public class User extends BaseEntity {
@@ -32,7 +33,7 @@ public class User extends BaseEntity {
 	private String name; // 유저명
 
 	@Column(nullable = false)
-	private long point; // 유저 보유포인트
+	private long point = 0L; // 유저 보유포인트
 
 	// 연관관계
 	@OneToMany(mappedBy = "user")
@@ -42,6 +43,11 @@ public class User extends BaseEntity {
 	// 비즈니스 정책
 	public final static long CHARGE_POINT_MINIMUM = 1000;
 	public final static long CHARGE_POINT_MAXIMUM = 100000;
+
+	public static void validateAmount(long amount) {
+
+	}
+
 	/**
 	 * chargePoint: 포인트 충전
 	 * @param amount long : 충전금액

--- a/src/main/java/io/hhplus/concert/domain/user/exceptions/messages/UserExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/user/exceptions/messages/UserExceptionMessage.java
@@ -1,0 +1,11 @@
+package io.hhplus.concert.domain.user.exceptions.messages;
+
+import static io.hhplus.concert.domain.user.entity.User.*;
+
+public interface UserExceptionMessage {
+	String AMOUNT_SHOULD_BE_POSITIVE_NUMBER ="금액값은 0보다 큰 양수여야 합니다.";
+	String CHARGE_AMOUNT_SHOULD_BE_MORE_THAN_MINIMUM="충전금액의 최소값("+CHARGE_POINT_MINIMUM+"원)보다 커야 합니다.";
+	String CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM="충전금액의 최대값("+CHARGE_POINT_MAXIMUM+"원)보다 작아야 합니다.";
+	String LACK_OF_YOUR_POINT ="잔액이 부족합니다.";
+
+}

--- a/src/main/java/io/hhplus/concert/domain/user/exceptions/messages/UserExceptionMessage.java
+++ b/src/main/java/io/hhplus/concert/domain/user/exceptions/messages/UserExceptionMessage.java
@@ -2,7 +2,9 @@ package io.hhplus.concert.domain.user.exceptions.messages;
 
 import static io.hhplus.concert.domain.user.entity.User.*;
 
-public interface UserExceptionMessage {
+import io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage;
+
+public interface UserExceptionMessage extends CommonExceptionMessage {
 	String AMOUNT_SHOULD_BE_POSITIVE_NUMBER ="금액값은 0보다 큰 양수여야 합니다.";
 	String CHARGE_AMOUNT_SHOULD_BE_MORE_THAN_MINIMUM="충전금액의 최소값("+CHARGE_POINT_MINIMUM+"원)보다 커야 합니다.";
 	String CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM="충전금액의 최대값("+CHARGE_POINT_MAXIMUM+"원)보다 작아야 합니다.";

--- a/src/main/java/io/hhplus/concert/domain/user/repository/UserRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/user/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.domain.user.repository;
+
+public interface UserRepository {
+}

--- a/src/main/java/io/hhplus/concert/domain/user/service/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/service/UserService.java
@@ -1,0 +1,12 @@
+package io.hhplus.concert.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import io.hhplus.concert.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertDateJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertDateJpaRepository.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.infrastructure.persistence.concert;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.hhplus.concert.domain.concert.entity.ConcertDate;
+
+public interface ConcertDateJpaRepository extends JpaRepository<ConcertDate, Long> {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertJpaRepository.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.infrastructure.persistence.concert;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.hhplus.concert.domain.concert.entity.Concert;
+
+public interface ConcertJpaRepository extends JpaRepository<Concert, Long> {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertRepositoryImpl.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.infrastructure.persistence.concert;
+
+import io.hhplus.concert.domain.concert.repository.ConcertDateRepository;
+import io.hhplus.concert.domain.concert.repository.ConcertRepository;
+import io.hhplus.concert.domain.concert.repository.SeatRepository;
+
+public class ConcertRepositoryImpl implements ConcertRepository, ConcertDateRepository, SeatRepository {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/SeatJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/SeatJpaRepository.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.infrastructure.persistence.concert;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.hhplus.concert.domain.concert.entity.Seat;
+
+public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/payment/PaymentJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/payment/PaymentJpaRepository.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.infrastructure.persistence.payment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.hhplus.concert.domain.payment.entity.Payment;
+
+public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/payment/PaymentRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/payment/PaymentRepositoryImpl.java
@@ -1,0 +1,6 @@
+package io.hhplus.concert.infrastructure.persistence.payment;
+
+import io.hhplus.concert.domain.payment.repository.PaymentRepository;
+
+public class PaymentRepositoryImpl implements PaymentRepository {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/reservation/ReservationJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/reservation/ReservationJpaRepository.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.infrastructure.persistence.reservation;
+
+public interface ReservationJpaRepository {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/reservation/ReservationRepositoryImpl.java
@@ -1,0 +1,6 @@
+package io.hhplus.concert.infrastructure.persistence.reservation;
+
+import io.hhplus.concert.domain.reservation.repository.ReservationRepository;
+
+public class ReservationRepositoryImpl implements ReservationRepository {
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.infrastructure.persistence.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.hhplus.concert.domain.user.entity.User;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponse.java
@@ -1,0 +1,31 @@
+package io.hhplus.concert.interfaces.api.common.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+	private final int status;
+	private final String message;
+	private final T data;
+
+	private ApiResponse(int status, String message, T data) {
+		this.status = status;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static<T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(HttpStatus.OK.value(), "OK", data);
+	}
+
+	public static<T> ApiResponse<T> created(T data) {
+		return new ApiResponse<>(HttpStatus.CREATED.value(), "CREATED", data);
+	}
+
+	public static<T> ApiResponse<T> of(int status, String message, T data) {
+		return new ApiResponse<>(status, message, data);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponse.java
@@ -17,7 +17,7 @@ public class ApiResponse<T> {
 		this.data = data;
 	}
 
-	public static<T> ApiResponse<T> success(T data) {
+	public static<T> ApiResponse<T> ok(T data) {
 		return new ApiResponse<>(HttpStatus.OK.value(), "OK", data);
 	}
 

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponseEntity.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponseEntity.java
@@ -7,7 +7,7 @@ import org.springframework.http.ResponseEntity;
 
 public class ApiResponseEntity {
 	public static <T>ResponseEntity<ApiResponse<T>> ok(T data) {
-		return ResponseEntity.ok(ApiResponse.success(data));
+		return ResponseEntity.ok(ApiResponse.ok(data));
 	}
 	public static<T>ResponseEntity<ApiResponse<T>> created(T data) {
 		return ResponseEntity

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponseEntity.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponseEntity.java
@@ -1,0 +1,22 @@
+package io.hhplus.concert.interfaces.api.common.dto;
+
+import java.net.URI;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ApiResponseEntity {
+	public static <T>ResponseEntity<ApiResponse<T>> ok(T data) {
+		return ResponseEntity.ok(ApiResponse.success(data));
+	}
+	public static<T>ResponseEntity<ApiResponse<T>> created(T data) {
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(ApiResponse.created(data));
+	}
+	public static<T> ResponseEntity<ApiResponse<T>> of(HttpStatus status, String message, T data) {
+		return ResponseEntity
+			.status(status)
+			.body(ApiResponse.of(status.value(), message, data));
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ErrorResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ErrorResponse.java
@@ -1,0 +1,15 @@
+package io.hhplus.concert.interfaces.api.common.dto;
+
+public class ErrorResponse {
+	private final int status;
+	private final String message;
+
+	private ErrorResponse(int status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	public static ErrorResponse of(int status, String message) {
+		return new ErrorResponse(status, message);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/exception/GlobalExceptionHandler.java
@@ -3,15 +3,20 @@ package io.hhplus.concert.interfaces.api.common.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import io.hhplus.concert.domain.common.exceptions.InvalidValidationException;
 import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
+import io.hhplus.concert.interfaces.api.concert.controller.ConcertController;
+import io.hhplus.concert.interfaces.api.payment.controller.PaymentController;
+import io.hhplus.concert.interfaces.api.point.controller.PointController;
+import io.hhplus.concert.interfaces.api.reservation.controller.ReservationController;
+import io.hhplus.concert.interfaces.api.token.controller.TokenController;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-@RestControllerAdvice
 public class GlobalExceptionHandler {
 
 	// 유효성검사 실패로 발생한 예외처리: 400 에러반환

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package io.hhplus.concert.interfaces.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import io.hhplus.concert.domain.common.exceptions.InvalidValidationException;
+import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	// 유효성검사 실패로 발생한 예외처리: 400 에러반환
+	@ApiResponse(
+		responseCode = "400",
+		description = "BAD_REQUEST",
+		content=@Content(
+			schema = @Schema(
+				implementation = ErrorResponse.class,
+				example = "{\"statusCode\":400,\"message\":\"Invalid Validation Exception\"}"
+			)
+		)
+	)
+	@ExceptionHandler(InvalidValidationException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleInvalidValidationException(InvalidValidationException e) {
+		return ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), e.getMessage());
+	}
+	// 서버내부 오류로 발생한 예외처리: 500 에러반환
+	@ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content=@Content(
+			schema = @Schema(
+				implementation = ErrorResponse.class,
+				example = "{\"statusCode\":500,\"message\":\"Internal Service Error\"}"
+			)
+		)
+	)
+	@ExceptionHandler(Exception.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	public ErrorResponse handleException(Exception e) {
+		return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertApiDocs.java
@@ -1,6 +1,7 @@
 package io.hhplus.concert.interfaces.api.concert.controller;
 
 import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+import static io.hhplus.concert.domain.token.service.exception.messages.TokenExceptionMessage.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -69,8 +70,24 @@ public interface ConcertApiDocs {
 			schema = @Schema(
 				implementation = ErrorResponse.class),
 			examples= @ExampleObject(
-				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+				value= "{\"status\":401,\"message\":\""+EXPIRED_OR_UNAVAILABLE_TOKEN+"\"}"
 			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
+			}
 		)
 	)
 	public ResponseEntity<ApiResponse<List<String>>> getAvailableConcertDate(@PathVariable("id") long id, @RequestHeader("token") String token);
@@ -116,7 +133,7 @@ public interface ConcertApiDocs {
 			schema = @Schema(
 				implementation = ErrorResponse.class),
 			examples= @ExampleObject(
-				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+				value= "{\"status\":401,\"message\":\""+EXPIRED_OR_UNAVAILABLE_TOKEN+"\"}"
 			)
 		)
 	)
@@ -133,6 +150,22 @@ public interface ConcertApiDocs {
 					summary = "id는 0보다 큰 양수이다",
 					value = "{\"statusCode\":400,\"message\":\"" + ID_SHOULD_BE_POSITIVE_NUMBER + "\"}"
 				),
+			}
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
 			}
 		)
 	)

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertApiDocs.java
@@ -1,5 +1,7 @@
 package io.hhplus.concert.interfaces.api.concert.controller;
 
+import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -13,6 +15,7 @@ import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
 import io.hhplus.concert.interfaces.api.concert.dto.SeatResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -20,21 +23,117 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface ConcertApiDocs {
 
 	@Operation(summary = "예약가능한 날짜 조회", description="특정 콘서트 중 예약가능한 콘서트날짜 목록을 반환")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "OK",
+		content= @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(
+				name = "예약 가능한 날짜 목록 조회 성공 응답 예시",
+				summary = "예약 가능한 날짜 목록 조회 성공 응답 데이터",
+				value= """
+					{
+					  "status": 200,
+					  "message": "OK",
+					  "data": [
+						"2025-04-04",
+						"2025-04-05",
+						"2025-04-11"
+					  ]
+					}
+					"""
+			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "400",
+		description = "BAD_REQUEST",
 		content = @Content(
-			schema = @Schema(implementation = ErrorResponse.class,
-				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name=ID_SHOULD_BE_POSITIVE_NUMBER,
+					summary = "id는 0보다 큰 양수이다",
+					value = "{\"statusCode\":400,\"message\":\"" + ID_SHOULD_BE_POSITIVE_NUMBER + "\"}"
+				),
+			}
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "401",
+		description = "UNAUTHORIZED",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= @ExampleObject(
+				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+			)
 		)
 	)
 	public ResponseEntity<ApiResponse<List<String>>> getAvailableConcertDate(@PathVariable("id") long id, @RequestHeader("token") String token);
 
 	@Operation(summary = "예약가능한 콘서트좌석 정보조회", description="특정 콘서트와 예약가능한 날짜에서 예약가능한 좌석목록을 반환 (최소 1개~최대 50개)")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "OK",
+		content= @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(
+				name = "예약 가능한 콘서트 좌석 목록 조회 성공 응답 예시",
+				summary = "예약 가능한 콘서트 좌석 목록 조회 성공 응답 데이터",
+				value= """
+				{
+				  "status": 200,
+				  "message": "OK",
+				  "data": [
+						{
+							"id": 51,
+							"number": 1,
+							"isAvailable": true
+						},{
+							"id": 52,
+							"number": 2,
+							"isAvailable": true
+						},{
+							"id": 53,
+							"number": 3,
+							"isAvailable": false
+						}
+					]
+				}
+				"""
+			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "401",
+		description = "UNAUTHORIZED",
 		content = @Content(
-			schema = @Schema(implementation = ErrorResponse.class,
-				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= @ExampleObject(
+				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "400",
+		description = "BAD_REQUEST",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name=ID_SHOULD_BE_POSITIVE_NUMBER,
+					summary = "id는 0보다 큰 양수이다",
+					value = "{\"statusCode\":400,\"message\":\"" + ID_SHOULD_BE_POSITIVE_NUMBER + "\"}"
+				),
+			}
 		)
 	)
 	public ResponseEntity<ApiResponse<List<SeatResponse>>> getAvailableSeats(@PathVariable("id") long id, @RequestParam("date") LocalDate date,  @RequestHeader("token") String token);

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertApiDocs.java
@@ -1,0 +1,42 @@
+package io.hhplus.concert.interfaces.api.concert.controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
+import io.hhplus.concert.interfaces.api.concert.dto.SeatResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Concert")
+public interface ConcertApiDocs {
+
+	@Operation(summary = "예약가능한 날짜 조회", description="특정 콘서트 중 예약가능한 콘서트날짜 목록을 반환")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+		content = @Content(
+			schema = @Schema(implementation = ErrorResponse.class,
+				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+		)
+	)
+	public ResponseEntity<ApiResponse<List<String>>> getAvailableConcertDate(@PathVariable("id") long id, @RequestHeader("token") String token);
+
+	@Operation(summary = "예약가능한 콘서트좌석 정보조회", description="특정 콘서트와 예약가능한 날짜에서 예약가능한 좌석목록을 반환 (최소 1개~최대 50개)")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+		content = @Content(
+			schema = @Schema(implementation = ErrorResponse.class,
+				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+		)
+	)
+	public ResponseEntity<ApiResponse<List<SeatResponse>>> getAvailableSeats(@PathVariable("id") long id, @RequestParam("date") LocalDate date,  @RequestHeader("token") String token);
+
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
@@ -25,8 +25,7 @@ public class ConcertController implements ConcertApiDocs {
 	@GetMapping("{id}/dates")
 	public ResponseEntity<ApiResponse<List<String>>> getAvailableConcertDate(@PathVariable("id") long id, @RequestHeader("token") String token) {
 		List<String> dates = List.of("2025-04-04", "2025-04-11");
-		ApiResponse<List<String>> response = ApiResponse.ok(dates);
-		return ResponseEntity.ok(response);
+		return ApiResponseEntity.ok(dates);
 	}
 
 	// 특정날짜에서 예약가능한 좌석정보조회
@@ -37,7 +36,6 @@ public class ConcertController implements ConcertApiDocs {
 			SeatResponse.of(52L, 2, true),
 			SeatResponse.of(53L, 3, true)
 		);
-		ApiResponse<List<SeatResponse>> response = ApiResponse.ok(availableSeats);
-		return ResponseEntity.ok(response);
+		return ApiResponseEntity.ok(availableSeats);
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
@@ -1,0 +1,20 @@
+package io.hhplus.concert.interfaces.api.concert.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("concerts")
+@RequiredArgsConstructor
+public class ConcertController {
+	// 예약가능 날짜 목록조회
+	@GetMapping("{concert_id}/dates")
+	public void getAvailableConcertDate() {}
+
+	// 특정날짜에서 예약가능한 좌석정보조회
+	@GetMapping("{concert_id}/seats?date={date}")
+	public void getAvailableSeats() {}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("concerts")
 @RequiredArgsConstructor
-public class ConcertController {
+public class ConcertController implements ConcertApiDocs {
 	// 예약가능 날짜 목록조회
 	@GetMapping("{id}/dates")
 	public ResponseEntity<ApiResponse<List<String>>> getAvailableConcertDate(@PathVariable("id") long id, @RequestHeader("token") String token) {
@@ -30,7 +30,7 @@ public class ConcertController {
 	}
 
 	// 특정날짜에서 예약가능한 좌석정보조회
-	@GetMapping("{id}/seats?date={date}")
+	@GetMapping("{id}/seats")
 	public ResponseEntity<ApiResponse<List<SeatResponse>>> getAvailableSeats(@PathVariable("id") long id, @RequestParam("date")LocalDate date,  @RequestHeader("token") String token) {
 		List<SeatResponse> availableSeats = List.of(
 			SeatResponse.of(51L, 1, true),

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/controller/ConcertController.java
@@ -1,9 +1,20 @@
 package io.hhplus.concert.interfaces.api.concert.controller;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.hhplus.concert.domain.concert.entity.Seat;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponseEntity;
+import io.hhplus.concert.interfaces.api.concert.dto.SeatResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -11,10 +22,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ConcertController {
 	// 예약가능 날짜 목록조회
-	@GetMapping("{concert_id}/dates")
-	public void getAvailableConcertDate() {}
+	@GetMapping("{id}/dates")
+	public ResponseEntity<ApiResponse<List<String>>> getAvailableConcertDate(@PathVariable("id") long id, @RequestHeader("token") String token) {
+		List<String> dates = List.of("2025-04-04", "2025-04-11");
+		ApiResponse<List<String>> response = ApiResponse.ok(dates);
+		return ResponseEntity.ok(response);
+	}
 
 	// 특정날짜에서 예약가능한 좌석정보조회
-	@GetMapping("{concert_id}/seats?date={date}")
-	public void getAvailableSeats() {}
+	@GetMapping("{id}/seats?date={date}")
+	public ResponseEntity<ApiResponse<List<SeatResponse>>> getAvailableSeats(@PathVariable("id") long id, @RequestParam("date")LocalDate date,  @RequestHeader("token") String token) {
+		List<SeatResponse> availableSeats = List.of(
+			SeatResponse.of(51L, 1, true),
+			SeatResponse.of(52L, 2, true),
+			SeatResponse.of(53L, 3, true)
+		);
+		ApiResponse<List<SeatResponse>> response = ApiResponse.ok(availableSeats);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/dto/SeatResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/dto/SeatResponse.java
@@ -1,0 +1,10 @@
+package io.hhplus.concert.interfaces.api.concert.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SeatResponse (long id, int number ,boolean isAvailable){
+	public static SeatResponse of(long id, int number, boolean isAvailable) {
+		return SeatResponse.builder().id(id).number(number).isAvailable(isAvailable).build();
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentApiDocs.java
@@ -1,0 +1,32 @@
+package io.hhplus.concert.interfaces.api.payment.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
+import io.hhplus.concert.interfaces.api.payment.dto.PaymentRequest;
+import io.hhplus.concert.interfaces.api.payment.dto.PaymentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Payment")
+public interface PaymentApiDocs {
+	@Operation(summary = "결제 요청", description="임시좌석배정 유효시간(5분) 이내에 결제완료시 좌석예약 확정")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CREATED")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "408", description = "REQUEST_TIMEOUT",
+		content = @Content(
+			schema = @Schema(implementation = ErrorResponse.class,
+				example= "{\"statusCode\":408,\"message\":\"임시배정된 좌석의 유효시간이 만료되었습니다.\"}")
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+		content = @Content(
+			schema = @Schema(implementation = ErrorResponse.class,
+				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+		)
+	)
+	public ResponseEntity<ApiResponse<PaymentResponse>> processPayment(@RequestBody PaymentRequest request);
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentApiDocs.java
@@ -1,5 +1,7 @@
 package io.hhplus.concert.interfaces.api.payment.controller;
 
+import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -9,23 +11,77 @@ import io.hhplus.concert.interfaces.api.payment.dto.PaymentRequest;
 import io.hhplus.concert.interfaces.api.payment.dto.PaymentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name="Payment")
 public interface PaymentApiDocs {
 	@Operation(summary = "결제 요청", description="임시좌석배정 유효시간(5분) 이내에 결제완료시 좌석예약 확정")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CREATED")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "408", description = "REQUEST_TIMEOUT",
-		content = @Content(
-			schema = @Schema(implementation = ErrorResponse.class,
-				example= "{\"statusCode\":408,\"message\":\"임시배정된 좌석의 유효시간이 만료되었습니다.\"}")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "201",
+		description = "CREATED",
+		content= @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(
+				name="결제 요청 성공 응답 예시",
+				summary = "결제 요청 성공 응답 데이터",
+				value = """
+					{
+						  "status": 201,
+						  "message": "CREATED",
+						  "data": {
+						       "concertId": 1,
+						       "reservationId": 1,
+						       "userId": 1,
+						       "concertDate": "2025-04-05",
+						       "seatNo": 1,
+						       "price": 15000,
+						       "confirmedAt": "2025-04-04T05:40:45.943Z"
+						  }
+					}	
+					"""
+			)
 		)
 	)
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "400",
+		description = "BAD_REQUEST",
 		content = @Content(
-			schema = @Schema(implementation = ErrorResponse.class,
-				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name=ID_SHOULD_BE_POSITIVE_NUMBER,
+					summary = "id는 0보다 큰 양수이다",
+					value = "{\"statusCode\":400,\"message\":\"" + ID_SHOULD_BE_POSITIVE_NUMBER + "\"}"
+				),
+			}
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "408",
+		description = "REQUEST_TIMEOUT",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= @ExampleObject(
+				value= "{\"status\":408,\"message\":\"임시배정된 좌석의 유효시간이 만료되었습니다.\"}"
+			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "401",
+		description = "UNAUTHORIZED",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= @ExampleObject(
+				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+			)
 		)
 	)
 	public ResponseEntity<ApiResponse<PaymentResponse>> processPayment(@RequestBody PaymentRequest request);

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentApiDocs.java
@@ -1,6 +1,8 @@
 package io.hhplus.concert.interfaces.api.payment.controller;
 
 import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+import static io.hhplus.concert.domain.concert.exceptions.messages.ConcertExceptionMessage.*;
+import static io.hhplus.concert.domain.token.service.exception.messages.TokenExceptionMessage.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -68,7 +70,7 @@ public interface PaymentApiDocs {
 			schema = @Schema(
 				implementation = ErrorResponse.class),
 			examples= @ExampleObject(
-				value= "{\"status\":408,\"message\":\"임시배정된 좌석의 유효시간이 만료되었습니다.\"}"
+				value= "{\"status\":408,\"message\":\""+TEMPORARY_RESERVED_TIMEOUT+"\"}"
 			)
 		)
 	)
@@ -80,8 +82,24 @@ public interface PaymentApiDocs {
 			schema = @Schema(
 				implementation = ErrorResponse.class),
 			examples= @ExampleObject(
-				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+				value= "{\"status\":401,\"message\":\""+EXPIRED_OR_UNAVAILABLE_TOKEN+"\"}"
 			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
+			}
 		)
 	)
 	public ResponseEntity<ApiResponse<PaymentResponse>> processPayment(@RequestBody PaymentRequest request);

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
@@ -22,7 +22,7 @@ public class PaymentController {
 	@PostMapping()
 	public ResponseEntity<ApiResponse<PaymentResponse>> processPayment(@RequestBody PaymentRequest request) {
 		PaymentResponse response = PaymentResponse.builder()
-			.reservationId(request.getReservationId())
+			.reservationId(request.reservationId())
 			.userId(1L)
 			.concertId(1L)
 			.concertDate(LocalDate.of(2025,4,1))

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponseEntity;
 import io.hhplus.concert.interfaces.api.payment.dto.PaymentRequest;
 import io.hhplus.concert.interfaces.api.payment.dto.PaymentResponse;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,6 @@ public class PaymentController implements PaymentApiDocs {
 			.seatNo(4)
 			.price(15000)
 			.confirmedAt(LocalDateTime.now()).build();
-		return ResponseEntity.ok(ApiResponse.created(response));
+		return ApiResponseEntity.created(response);
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.interfaces.api.payment.controller;
+
+public class PaymentController {
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("payments")
 @RequiredArgsConstructor
-public class PaymentController {
+public class PaymentController implements PaymentApiDocs {
 	// 임시 예약 좌석 결제
 	@PostMapping()
 	public ResponseEntity<ApiResponse<PaymentResponse>> processPayment(@RequestBody PaymentRequest request) {

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/controller/PaymentController.java
@@ -1,4 +1,34 @@
 package io.hhplus.concert.interfaces.api.payment.controller;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.payment.dto.PaymentRequest;
+import io.hhplus.concert.interfaces.api.payment.dto.PaymentResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("payments")
+@RequiredArgsConstructor
 public class PaymentController {
+	// 임시 예약 좌석 결제
+	@PostMapping()
+	public ResponseEntity<ApiResponse<PaymentResponse>> processPayment(@RequestBody PaymentRequest request) {
+		PaymentResponse response = PaymentResponse.builder()
+			.reservationId(request.getReservationId())
+			.userId(1L)
+			.concertId(1L)
+			.concertDate(LocalDate.of(2025,4,1))
+			.seatNo(4)
+			.price(15000)
+			.confirmedAt(LocalDateTime.now()).build();
+		return ResponseEntity.ok(ApiResponse.created(response));
+	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentRequest.java
@@ -1,0 +1,11 @@
+package io.hhplus.concert.interfaces.api.payment.dto;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import lombok.Data;
+
+@Data
+public record PaymentRequest(long reservationId) {
+	public PaymentRequest {
+		BaseEntity.validateId(reservationId);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentRequest.java
@@ -3,7 +3,6 @@ package io.hhplus.concert.interfaces.api.payment.dto;
 import io.hhplus.concert.domain.common.entity.BaseEntity;
 import lombok.Data;
 
-@Data
 public record PaymentRequest(long reservationId) {
 	public PaymentRequest {
 		BaseEntity.validateId(reservationId);

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentRequest.java
@@ -1,9 +1,13 @@
 package io.hhplus.concert.interfaces.api.payment.dto;
 
 import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-public record PaymentRequest(long reservationId) {
+public record PaymentRequest(
+	@Schema(description = "예약 ID", example="1")
+	long reservationId
+) {
 	public PaymentRequest {
 		BaseEntity.validateId(reservationId);
 	}

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/dto/PaymentResponse.java
@@ -1,0 +1,29 @@
+package io.hhplus.concert.interfaces.api.payment.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentResponse(long concertId, long reservationId, long userId, LocalDate concertDate, int seatNo, long price, LocalDateTime confirmedAt) {
+	public PaymentResponse of(
+		long concertId,
+		long reservationId,
+		long userId,
+		LocalDate concertDate,
+		int seatNo,
+		long price,
+		LocalDateTime confirmedAt
+	) {
+		return PaymentResponse.builder()
+			.userId(userId)
+			.concertId(concertId)
+			.reservationId(reservationId)
+			.concertDate(concertDate)
+			.seatNo(seatNo)
+			.price(price)
+			.confirmedAt(confirmedAt)
+			.build();
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointApiDocs.java
@@ -1,5 +1,8 @@
 package io.hhplus.concert.interfaces.api.point.controller;
 
+import static io.hhplus.concert.domain.user.entity.User.*;
+import static io.hhplus.concert.domain.user.exceptions.messages.UserExceptionMessage.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -10,23 +13,75 @@ import io.hhplus.concert.interfaces.api.point.dto.PointRequest;
 import io.hhplus.concert.interfaces.api.point.dto.PointResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name="Point")
 public interface PointApiDocs {
 	@Operation(summary = "잔액 충전", description="잔액 포인트를 충전")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "OK",
 		content = @Content(
-			schema = @Schema(implementation = ErrorResponse.class,
-				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+			mediaType = "application/json",
+			examples = @ExampleObject(
+				name ="잔액 충전 성공 응답 예시",
+				summary = "잔액 충전 성공 응답 데이터",
+				value= """
+					{
+					  "status": 200,
+					  "message": "OK",
+					  "data": {
+						"id": 1,
+						"point": 10500
+					  }
+					}	
+					"""
+			)
 		)
 	)
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "BAD_REQUEST",
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "401",
+		description = "UNAUTHORIZED",
 		content = @Content(
-			schema = @Schema(implementation = ErrorResponse.class,
-				example= "{\"statusCode\":400,\"message\":\"포인트 금액이 적합하지 않습니다.\"}")
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= @ExampleObject(
+				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "400",
+		description = "BAD_REQUEST",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name=ID_SHOULD_BE_POSITIVE_NUMBER,
+					summary = "id는 0보다 큰 양수이다",
+					value = "{\"statusCode\":400,\"message\":\"" + ID_SHOULD_BE_POSITIVE_NUMBER + "\"}"
+				),
+				@ExampleObject(
+					name=AMOUNT_SHOULD_BE_POSITIVE_NUMBER,
+					summary = "충전금액은 0보다 큰 양수이다",
+					value = "{\"statusCode\":400,\"message\":\"" + AMOUNT_SHOULD_BE_POSITIVE_NUMBER + "\"}"
+				),
+				@ExampleObject(
+					name=CHARGE_AMOUNT_SHOULD_BE_MORE_THAN_MINIMUM,
+					summary = "최소 충전금액은 "+CHARGE_POINT_MINIMUM+"원 이다",
+					value = "{\"statusCode\":400,\"message\":\"" + CHARGE_AMOUNT_SHOULD_BE_MORE_THAN_MINIMUM + "\"}"
+				),
+				@ExampleObject(
+					name=CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM,
+					summary = "최대 충전금액은 "+CHARGE_POINT_MAXIMUM+"원 이다",
+					value = "{\"statusCode\":400,\"message\":\"" + CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM + "\"}"
+				),
+			}
 		)
 	)
 	public ResponseEntity<ApiResponse<PointResponse>> chargePoint(@RequestHeader("token") String token, @RequestBody
@@ -34,6 +89,38 @@ public interface PointApiDocs {
 
 
 	@Operation(summary = "잔액 조회", description="보유잔액을 조회")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "OK",
+		content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(
+				name="잔액 조회 성공 응답 예시",
+				summary = "잔액 조회 성공 응답 데이터",
+				value = """
+				{
+					"status": 200,
+					"message": "OK",
+					"data": {
+					   "id": 1,
+					   "point": 1000
+					}
+			   	}
+				"""
+			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "401",
+		description = "UNAUTHORIZED",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= @ExampleObject(
+				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+			)
+		)
+	)
 	public ResponseEntity<ApiResponse<PointResponse>> getPoint( @RequestHeader("token") String token);
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointApiDocs.java
@@ -1,5 +1,6 @@
 package io.hhplus.concert.interfaces.api.point.controller;
 
+import static io.hhplus.concert.domain.token.service.exception.messages.TokenExceptionMessage.*;
 import static io.hhplus.concert.domain.user.entity.User.*;
 import static io.hhplus.concert.domain.user.exceptions.messages.UserExceptionMessage.*;
 
@@ -49,7 +50,7 @@ public interface PointApiDocs {
 			schema = @Schema(
 				implementation = ErrorResponse.class),
 			examples= @ExampleObject(
-				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+				value= "{\"status\":401,\"message\":\""+EXPIRED_OR_UNAVAILABLE_TOKEN+"\"}"
 			)
 		)
 	)
@@ -81,6 +82,22 @@ public interface PointApiDocs {
 					summary = "최대 충전금액은 "+CHARGE_POINT_MAXIMUM+"원 이다",
 					value = "{\"statusCode\":400,\"message\":\"" + CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM + "\"}"
 				),
+			}
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
 			}
 		)
 	)
@@ -118,8 +135,24 @@ public interface PointApiDocs {
 			schema = @Schema(
 				implementation = ErrorResponse.class),
 			examples= @ExampleObject(
-				value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+				value= "{\"status\":401,\"message\":\""+EXPIRED_OR_UNAVAILABLE_TOKEN+"\"}"
 			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
+			}
 		)
 	)
 	public ResponseEntity<ApiResponse<PointResponse>> getPoint( @RequestHeader("token") String token);

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointApiDocs.java
@@ -1,0 +1,39 @@
+package io.hhplus.concert.interfaces.api.point.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
+import io.hhplus.concert.interfaces.api.point.dto.PointRequest;
+import io.hhplus.concert.interfaces.api.point.dto.PointResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Point")
+public interface PointApiDocs {
+	@Operation(summary = "잔액 충전", description="잔액 포인트를 충전")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "UNAUTHORIZED",
+		content = @Content(
+			schema = @Schema(implementation = ErrorResponse.class,
+				example= "{\"statusCode\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}")
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "BAD_REQUEST",
+		content = @Content(
+			schema = @Schema(implementation = ErrorResponse.class,
+				example= "{\"statusCode\":400,\"message\":\"포인트 금액이 적합하지 않습니다.\"}")
+		)
+	)
+	public ResponseEntity<ApiResponse<PointResponse>> chargePoint(@RequestHeader("token") String token, @RequestBody
+	PointRequest request);
+
+
+	@Operation(summary = "잔액 조회", description="보유잔액을 조회")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
+	public ResponseEntity<ApiResponse<PointResponse>> getPoint( @RequestHeader("token") String token);
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
@@ -22,14 +22,14 @@ public class PointController implements PointApiDocs {
 	@PatchMapping()
 	public ResponseEntity<ApiResponse<PointResponse>> chargePoint(@RequestHeader("token") String token, @RequestBody
 		PointRequest request) {
-		PointResponse response = PointResponse.builder().id(1L).point(50000L).build();
+		PointResponse response = PointResponse.of(1L, 50000L);
 		return ApiResponseEntity.ok(response);
 	}
 
 	// 포인트 잔액 조회
 	@GetMapping()
 	public ResponseEntity<ApiResponse<PointResponse>> getPoint( @RequestHeader("token") String token){
-		PointResponse response = PointResponse.builder().id(1L).point(50000L).build();
+		PointResponse response = PointResponse.of(1L, 50000L);
 		return ApiResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.interfaces.api.point.controller;
+
+public class PointController {
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("points")
 @RequiredArgsConstructor
-public class PointController {
+public class PointController implements PointApiDocs {
 	// 잔액 충전
 	@PatchMapping()
 	public ResponseEntity<ApiResponse<PointResponse>> chargePoint(@RequestHeader("token") String token, @RequestBody

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/controller/PointController.java
@@ -1,4 +1,35 @@
 package io.hhplus.concert.interfaces.api.point.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponseEntity;
+import io.hhplus.concert.interfaces.api.point.dto.PointRequest;
+import io.hhplus.concert.interfaces.api.point.dto.PointResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("points")
+@RequiredArgsConstructor
 public class PointController {
+	// 잔액 충전
+	@PatchMapping()
+	public ResponseEntity<ApiResponse<PointResponse>> chargePoint(@RequestHeader("token") String token, @RequestBody
+		PointRequest request) {
+		PointResponse response = PointResponse.builder().id(1L).point(50000L).build();
+		return ApiResponseEntity.ok(response);
+	}
+
+	// 포인트 잔액 조회
+	@GetMapping()
+	public ResponseEntity<ApiResponse<PointResponse>> getPoint( @RequestHeader("token") String token){
+		PointResponse response = PointResponse.builder().id(1L).point(50000L).build();
+		return ApiResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointRequest.java
@@ -1,9 +1,15 @@
 package io.hhplus.concert.interfaces.api.point.dto;
 
 import io.hhplus.concert.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-public record PointRequest(long userId, long amount) {
+public record PointRequest(
+	@Schema(description = "유저 ID", example="1")
+	long userId,
+	@Schema(description = "충전금액", example="10000")
+	long amount
+) {
 	public PointRequest {
 		// 유효성검사
 		User.validateId(userId);

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointRequest.java
@@ -1,0 +1,12 @@
+package io.hhplus.concert.interfaces.api.point.dto;
+
+import io.hhplus.concert.domain.user.entity.User;
+import lombok.Data;
+
+@Data
+public record PointRequest(long userId, long amount) {
+	public PointRequest {
+		// 유효성검사
+		User.validateId(userId);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointRequest.java
@@ -3,7 +3,6 @@ package io.hhplus.concert.interfaces.api.point.dto;
 import io.hhplus.concert.domain.user.entity.User;
 import lombok.Data;
 
-@Data
 public record PointRequest(long userId, long amount) {
 	public PointRequest {
 		// 유효성검사

--- a/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/point/dto/PointResponse.java
@@ -1,0 +1,10 @@
+package io.hhplus.concert.interfaces.api.point.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PointResponse(long id, long point) {
+	public static PointResponse of(long id, long point) {
+		return PointResponse.builder().id(id).point(point).build();
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationApiDocs.java
@@ -1,19 +1,82 @@
 package io.hhplus.concert.interfaces.api.reservation.controller;
 
+import static io.hhplus.concert.domain.user.entity.User.*;
+import static io.hhplus.concert.domain.user.exceptions.messages.UserExceptionMessage.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
 import io.hhplus.concert.interfaces.api.reservation.dto.ReservationRequest;
 import io.hhplus.concert.interfaces.api.reservation.dto.ReservationResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name="Reservation")
 public interface ReservationApiDocs {
 	@Operation(summary = "좌석 예약 요청", description="좌석 예약 요청을 성공하면 5분간 임시배정 상태가 된다")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CREATED")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "201",
+		description = "CREATED",
+		content= @Content(
+			mediaType = "application/json",
+			examples= @ExampleObject(
+				name= "좌석 임시예약 성공 응답 예시",
+				summary = "좌석 임시예약 성공 응답 데이터",
+				value= """
+					{
+					  "status": 201,
+					  "message": "CREATED",
+					  "data": {
+						"reservationId": 10001,
+						"userId": 123,
+						"concertId": 1,
+						"concertDate": "2025-04-05",
+						"seatId": 5001,
+						"seatNo": 10,
+						"price": 15000,
+						"status": "PENDING_PAYMENT",
+						"reservedAt": "2025-04-04T11:00:00",
+						"tempReservationExpiredAt": "2025-04-04T11:05:00"
+					  }
+					}		
+				"""
+			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "400",
+		description = "BAD_REQUEST",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name=ID_SHOULD_BE_POSITIVE_NUMBER,
+					summary = "id는 0보다 큰 양수이다",
+					value = "{\"statusCode\":400,\"message\":\"" + ID_SHOULD_BE_POSITIVE_NUMBER + "\"}"
+				),
+			}
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "401",
+		description = "UNAUTHORIZED",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+				examples= @ExampleObject(
+					value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+			)
+		)
+	)
 	public ResponseEntity<ApiResponse<ReservationResponse>> reserveTemporarySeat(@RequestHeader("token") String token, @RequestBody
 	ReservationRequest request);
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationApiDocs.java
@@ -1,0 +1,19 @@
+package io.hhplus.concert.interfaces.api.reservation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.reservation.dto.ReservationRequest;
+import io.hhplus.concert.interfaces.api.reservation.dto.ReservationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Reservation")
+public interface ReservationApiDocs {
+	@Operation(summary = "좌석 예약 요청", description="좌석 예약 요청을 성공하면 5분간 임시배정 상태가 된다")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CREATED")
+	public ResponseEntity<ApiResponse<ReservationResponse>> reserveTemporarySeat(@RequestHeader("token") String token, @RequestBody
+	ReservationRequest request);
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationApiDocs.java
@@ -1,5 +1,8 @@
 package io.hhplus.concert.interfaces.api.reservation.controller;
 
+import static io.hhplus.concert.domain.concert.exceptions.messages.ConcertExceptionMessage.*;
+import static io.hhplus.concert.domain.reservation.exceptions.messages.ReservationExceptionMessage.*;
+import static io.hhplus.concert.domain.token.service.exception.messages.TokenExceptionMessage.*;
 import static io.hhplus.concert.domain.user.entity.User.*;
 import static io.hhplus.concert.domain.user.exceptions.messages.UserExceptionMessage.*;
 
@@ -73,8 +76,40 @@ public interface ReservationApiDocs {
 			schema = @Schema(
 				implementation = ErrorResponse.class),
 				examples= @ExampleObject(
-					value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
+					value= "{\"status\":401,\"message\":\""+EXPIRED_OR_UNAVAILABLE_TOKEN+"\"}"
 			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "409",
+		description = "CONFLICT",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+				examples= {
+				@ExampleObject(
+					name = ALREADY_RESERVED,
+					summary = "이미 결제가 완료되어 예약확정되거나 임시예약이 된 상태 좌석",
+					value= "{\"status\":409,\"message\":\"" + ALREADY_RESERVED + ".\"}"
+				)
+			}
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
+			}
 		)
 	)
 	public ResponseEntity<ApiResponse<ReservationResponse>> reserveTemporarySeat(@RequestHeader("token") String token, @RequestBody

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
@@ -28,8 +28,8 @@ public class ReservationController {
 		ReservationRequest request) {
 		ReservationResponse reservation = ReservationResponse.builder()
 			.reservationId(1001L)
-			.userId(request.getUserId())
-			.seatId(request.getSeatId())
+			.userId(request.userId())
+			.seatId(request.seatId())
 			.seatNo(10)
 			.price(15000)
 			.status(ReservationStatus.PENDING_PAYMENT)

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("reservations")
 @RequiredArgsConstructor
-public class ReservationController {
+public class ReservationController implements  ReservationApiDocs {
 	private final ReservationService reservationService;
 
 	// 좌석 예약요청

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
@@ -1,5 +1,6 @@
 package io.hhplus.concert.interfaces.api.reservation.controller;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.hhplus.concert.domain.reservation.entity.ReservationStatus;
 import io.hhplus.concert.domain.reservation.service.ReservationService;
 import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponseEntity;
 import io.hhplus.concert.interfaces.api.reservation.dto.ReservationRequest;
 import io.hhplus.concert.interfaces.api.reservation.dto.ReservationResponse;
 import lombok.RequiredArgsConstructor;
@@ -26,16 +28,19 @@ public class ReservationController implements  ReservationApiDocs {
 	@PostMapping()
 	public ResponseEntity<ApiResponse<ReservationResponse>> reserveTemporarySeat(@RequestHeader("token") String token, @RequestBody
 		ReservationRequest request) {
-		ReservationResponse reservation = ReservationResponse.builder()
-			.reservationId(1001L)
-			.userId(request.userId())
-			.seatId(request.seatId())
-			.seatNo(10)
-			.price(15000)
-			.status(ReservationStatus.PENDING_PAYMENT)
-			.reservedAt(LocalDateTime.of(2025,4,4,11,0,0))
-			.reservedAt(LocalDateTime.of(2025,4,4,11,5,0))
-			.build();
-		return ResponseEntity.ok(ApiResponse.ok(reservation));
+		ReservationResponse reservation = ReservationResponse.of(
+			10001L,
+			request.userId(),
+			1L,
+			LocalDate.of(2025,4,5),
+			request.seatId(),
+			10,
+			15000,
+			ReservationStatus.PENDING_PAYMENT,
+			LocalDateTime.of(2025,4,4,11,0,0),
+			LocalDateTime.of(2025,4,4,11,5,0)
+		);
+
+		return ApiResponseEntity.created(reservation);
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
@@ -1,0 +1,4 @@
+package io.hhplus.concert.interfaces.api.reservation.controller;
+
+public class ReservationController {
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/controller/ReservationController.java
@@ -1,4 +1,41 @@
 package io.hhplus.concert.interfaces.api.reservation.controller;
 
+import java.time.LocalDateTime;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.hhplus.concert.domain.reservation.entity.ReservationStatus;
+import io.hhplus.concert.domain.reservation.service.ReservationService;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.reservation.dto.ReservationRequest;
+import io.hhplus.concert.interfaces.api.reservation.dto.ReservationResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("reservations")
+@RequiredArgsConstructor
 public class ReservationController {
+	private final ReservationService reservationService;
+
+	// 좌석 예약요청
+	@PostMapping()
+	public ResponseEntity<ApiResponse<ReservationResponse>> reserveTemporarySeat(@RequestHeader("token") String token, @RequestBody
+		ReservationRequest request) {
+		ReservationResponse reservation = ReservationResponse.builder()
+			.reservationId(1001L)
+			.userId(request.getUserId())
+			.seatId(request.getSeatId())
+			.seatNo(10)
+			.price(15000)
+			.status(ReservationStatus.PENDING_PAYMENT)
+			.reservedAt(LocalDateTime.of(2025,4,4,11,0,0))
+			.reservedAt(LocalDateTime.of(2025,4,4,11,5,0))
+			.build();
+		return ResponseEntity.ok(ApiResponse.ok(reservation));
+	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationRequest.java
@@ -1,10 +1,16 @@
 package io.hhplus.concert.interfaces.api.reservation.dto;
 
 import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 
-public record ReservationRequest (long userId, long seatId) {
+public record ReservationRequest (
+	@Schema(description = "유저 ID", example="123")
+	long userId,
+	@Schema(description = "좌석 ID", example="5001")
+	long seatId
+) {
 	public ReservationRequest{
 		// 유효성검사
 		BaseEntity.validateId(userId);

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationRequest.java
@@ -3,9 +3,9 @@ package io.hhplus.concert.interfaces.api.reservation.dto;
 import io.hhplus.concert.domain.common.entity.BaseEntity;
 import lombok.Data;
 
-@Data
-public record ReservationRequest(long userId, long seatId) {
-	public ReservationRequest {
+
+public record ReservationRequest (long userId, long seatId) {
+	public ReservationRequest{
 		// 유효성검사
 		BaseEntity.validateId(userId);
 		BaseEntity.validateId(seatId);

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationRequest.java
@@ -1,0 +1,13 @@
+package io.hhplus.concert.interfaces.api.reservation.dto;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import lombok.Data;
+
+@Data
+public record ReservationRequest(long userId, long seatId) {
+	public ReservationRequest {
+		// 유효성검사
+		BaseEntity.validateId(userId);
+		BaseEntity.validateId(seatId);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationResponse.java
@@ -1,0 +1,48 @@
+package io.hhplus.concert.interfaces.api.reservation.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import io.hhplus.concert.domain.reservation.entity.ReservationStatus;
+import lombok.Builder;
+
+@Builder
+public record ReservationResponse(
+	long reservationId,
+	long userId,
+	long concertId,
+	LocalDate concertDate,
+	long seatId,
+	int seatNo,
+	long price,
+	ReservationStatus status,
+	LocalDateTime reservedAt,
+	LocalDateTime tempReservationExpiredAt
+) {
+	public static ReservationResponse of (
+		long reservationId,
+		long userId,
+		long concertId,
+		LocalDate concertDate,
+		long seatId,
+		int seatNo,
+		long price,
+		ReservationStatus status,
+		LocalDateTime reservedAt,
+		LocalDateTime tempReservationExpiredAt
+	) {
+		return ReservationResponse
+			.builder()
+			.reservationId(reservationId)
+			.userId(userId)
+			.concertId(concertId)
+			.concertDate(concertDate)
+			.seatId(seatId)
+			.seatNo(seatNo)
+			.price(price)
+			.status(status)
+			.reservedAt(reservedAt)
+			.tempReservationExpiredAt(tempReservationExpiredAt)
+			.build();
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/dto/ReservationResponse.java
@@ -4,11 +4,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import io.hhplus.concert.domain.reservation.entity.ReservationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record ReservationResponse(
+	@Schema(description="예약 ID", example= "1L")
 	long reservationId,
+	@Schema(description="유저 ID", example= "1L")
 	long userId,
 	long concertId,
 	LocalDate concertDate,

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenApiDocs.java
@@ -1,0 +1,32 @@
+package io.hhplus.concert.interfaces.api.token.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ErrorResponse;
+import io.hhplus.concert.interfaces.api.token.dto.TokenRequest;
+import io.hhplus.concert.interfaces.api.token.dto.TokenResponse;
+import io.hhplus.concert.interfaces.api.token.dto.TokenSequenceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Token")
+public interface TokenApiDocs {
+	@Operation(summary = "대기열 토큰 발급", description="콘서트 예약 진입시 대기열 토큰을 발급")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CREATED")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "NOT_FOUND",
+		content = @Content(
+			schema = @Schema(implementation = ErrorResponse.class,
+				example= "{\"statusCode\":404,\"message\":\"해당 사용자를 찾을 수 없습니다.\"}")
+		)
+	)
+	public ResponseEntity<ApiResponse<TokenResponse>> issueWaitingToken(@RequestBody TokenRequest request);
+
+	@Operation(summary = "대기열 순번 조회", description="대기열 통과까지 남은 순번을 조회")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
+	public ResponseEntity<ApiResponse<TokenSequenceResponse>> getWaitingTokenSequence(@RequestParam("token") String token);
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenApiDocs.java
@@ -11,22 +11,70 @@ import io.hhplus.concert.interfaces.api.token.dto.TokenResponse;
 import io.hhplus.concert.interfaces.api.token.dto.TokenSequenceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name="Token")
 public interface TokenApiDocs {
 	@Operation(summary = "대기열 토큰 발급", description="콘서트 예약 진입시 대기열 토큰을 발급")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CREATED")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "NOT_FOUND",
-		content = @Content(
-			schema = @Schema(implementation = ErrorResponse.class,
-				example= "{\"statusCode\":404,\"message\":\"해당 사용자를 찾을 수 없습니다.\"}")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "201",
+		description = "CREATED",
+		content= @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(
+				name="대기열 토큰 발급 성공",
+				description = "토큰발급이 성공하면 대기상태인 토큰을 응답한다",
+				value= """
+				{
+					 "status": 201,
+					 "message": "CREATED",
+					 "data": {
+					   "token": "sampleToken",
+					   "isActive": false
+					 }
+				}
+				"""
+			)
 		)
 	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "404",
+		description = "NOT_FOUND",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= @ExampleObject(
+				value= "{\"statusCode\":404,\"message\":\"해당 사용자를 찾을 수 없습니다.\"}"
+			)
+		)
+	)
+
 	public ResponseEntity<ApiResponse<TokenResponse>> issueWaitingToken(@RequestBody TokenRequest request);
 
 	@Operation(summary = "대기열 순번 조회", description="대기열 통과까지 남은 순번을 조회")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "OK",
+		content= @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(
+				name="대기열 순서 조회 성공",
+				description = "대기열은 최대 100개가 존재하며 현재 대기순서 위치를 나타낸다. 토큰의 상태는 대기 상태이다.",
+				value= """
+				{
+					 "status": 200,
+					 "message": "OK",
+					 "data": {
+					   "position": 10,
+					   "isActive": false
+					 }
+				}
+				"""
+			)
+		)
+	)
 	public ResponseEntity<ApiResponse<TokenSequenceResponse>> getWaitingTokenSequence(@RequestParam("token") String token);
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenApiDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenApiDocs.java
@@ -1,5 +1,7 @@
 package io.hhplus.concert.interfaces.api.token.controller;
 
+import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,7 +53,22 @@ public interface TokenApiDocs {
 			)
 		)
 	)
-
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
+			}
+		)
+	)
 	public ResponseEntity<ApiResponse<TokenResponse>> issueWaitingToken(@RequestBody TokenRequest request);
 
 	@Operation(summary = "대기열 순번 조회", description="대기열 통과까지 남은 순번을 조회")
@@ -74,6 +91,22 @@ public interface TokenApiDocs {
 				}
 				"""
 			)
+		)
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "500",
+		description = "INTERNAL_SERVER_ERROR",
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(
+				implementation = ErrorResponse.class),
+			examples= {
+				@ExampleObject(
+					name = INTERNAL_SERVER_ERROR,
+					summary = "서버내부 에러",
+					value= "{\"status\":500,\"message\":\"" + INTERNAL_SERVER_ERROR + ".\"}"
+				)
+			}
 		)
 	)
 	public ResponseEntity<ApiResponse<TokenSequenceResponse>> getWaitingTokenSequence(@RequestParam("token") String token);

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenController.java
@@ -5,12 +5,15 @@ import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.hhplus.concert.domain.token.service.TokenService;
 import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
 import io.hhplus.concert.interfaces.api.common.dto.ApiResponseEntity;
+import io.hhplus.concert.interfaces.api.token.dto.TokenRequest;
 import io.hhplus.concert.interfaces.api.token.dto.TokenResponse;
 
 import io.hhplus.concert.interfaces.api.token.dto.TokenSequenceResponse;
@@ -24,17 +27,15 @@ public class TokenController {
 
 	// 대기열 토큰 발급
 	@PostMapping()
-	public ResponseEntity<ApiResponse<TokenResponse>> issueWaitingToken() {
-		return ApiResponseEntity.created(
-			TokenResponse.of(UUID.randomUUID().toString(), false)
-		);
+	public ResponseEntity<ApiResponse<TokenResponse>> issueWaitingToken(@RequestBody TokenRequest request) {
+		TokenResponse response = TokenResponse.of(UUID.randomUUID().toString(), false);
+		return ApiResponseEntity.created(response);
 	}
 
 	// 대기 순번 조회 요청
 	@GetMapping("sequence")
-	public ResponseEntity<ApiResponse<TokenSequenceResponse>> getWaitingTokenSequence() {
-		return ApiResponseEntity.ok(
-			TokenSequenceResponse.of(15L, false)
-		);
+	public ResponseEntity<ApiResponse<TokenSequenceResponse>> getWaitingTokenSequence(@RequestParam("token") String token) {
+		TokenSequenceResponse response = TokenSequenceResponse.of(15L, false);
+		return ApiResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenController.java
@@ -1,0 +1,40 @@
+package io.hhplus.concert.interfaces.api.token.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.hhplus.concert.domain.token.service.TokenService;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponse;
+import io.hhplus.concert.interfaces.api.common.dto.ApiResponseEntity;
+import io.hhplus.concert.interfaces.api.token.dto.TokenResponse;
+
+import io.hhplus.concert.interfaces.api.token.dto.TokenSequenceResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("tokens")
+@RequiredArgsConstructor
+public class TokenController {
+	private final TokenService tokenService;
+
+	// 대기열 토큰 발급
+	@PostMapping()
+	public ResponseEntity<ApiResponse<TokenResponse>> issueWaitingToken() {
+		return ApiResponseEntity.created(
+			TokenResponse.of(UUID.randomUUID().toString(), false)
+		);
+	}
+
+	// 대기 순번 조회 요청
+	@GetMapping("sequence")
+	public ResponseEntity<ApiResponse<TokenSequenceResponse>> getWaitingTokenSequence() {
+		return ApiResponseEntity.ok(
+			TokenSequenceResponse.of(15L, false)
+		);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/controller/TokenController.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("tokens")
 @RequiredArgsConstructor
-public class TokenController {
+public class TokenController implements TokenApiDocs {
 	private final TokenService tokenService;
 
 	// 대기열 토큰 발급

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenRequest.java
@@ -1,0 +1,11 @@
+package io.hhplus.concert.interfaces.api.token.dto;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+
+
+public record TokenRequest(long userId) {
+	public TokenRequest {
+		// 유효성검사
+		BaseEntity.validateId(userId);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenRequest.java
@@ -1,9 +1,12 @@
 package io.hhplus.concert.interfaces.api.token.dto;
 
 import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-
-public record TokenRequest(long userId) {
+public record TokenRequest(
+	@Schema(description= "유저 ID", example="1234")
+	long userId
+) {
 	public TokenRequest {
 		// 유효성검사
 		BaseEntity.validateId(userId);

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenResponse.java
@@ -1,0 +1,13 @@
+package io.hhplus.concert.interfaces.api.token.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Builder
+public record TokenResponse (String token, boolean isActive){
+
+	public static TokenResponse of(String token, boolean isActive) {
+		return TokenResponse.builder().token(token).isActive(isActive).build();
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenSequenceResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/dto/TokenSequenceResponse.java
@@ -1,0 +1,12 @@
+package io.hhplus.concert.interfaces.api.token.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Builder
+public record TokenSequenceResponse(long position, boolean isActive){
+	public static TokenSequenceResponse of (long position, boolean isActive) {
+		return TokenSequenceResponse.builder().position(position).isActive(isActive).build();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,9 @@ spring:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operationSorter: method

--- a/src/test/java/io/hhplus/concert/domain/commons/entity/BaseEntityTest.java
+++ b/src/test/java/io/hhplus/concert/domain/commons/entity/BaseEntityTest.java
@@ -1,0 +1,24 @@
+package io.hhplus.concert.domain.commons.entity;
+
+import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.common.exceptions.InvalidValidationException;
+
+public class BaseEntityTest {
+	@Test
+	void 식별자가_0이하의값을_가지면_InvalidValidationException_예외발생(){
+		// given
+		long id = 0;
+
+		// when & then
+		InvalidValidationException ex = assertThrows(
+			InvalidValidationException.class,
+			()-> BaseEntity.validateId(id)
+		);
+		assertEquals(ID_SHOULD_BE_POSITIVE_NUMBER, ex.getMessage());
+	}
+}

--- a/src/test/java/io/hhplus/concert/domain/user/entity/UserEntityTest.java
+++ b/src/test/java/io/hhplus/concert/domain/user/entity/UserEntityTest.java
@@ -1,0 +1,111 @@
+package io.hhplus.concert.domain.user.entity;
+
+import static io.hhplus.concert.domain.common.exceptions.CommonExceptionMessage.*;
+import static io.hhplus.concert.domain.user.exceptions.messages.UserExceptionMessage.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.hhplus.concert.domain.common.entity.BaseEntity;
+import io.hhplus.concert.domain.common.exceptions.InvalidValidationException;
+
+public class UserEntityTest {
+	@Test
+	void 신규유저의_보유포인트는_0원이다() {
+		User user = new User();
+		assertEquals(user.getPoint(), 0);
+	}
+
+	@Test
+	void 충전금액이_0이하이면_InvalidValidationException_예외발생() {
+		// given
+		long amount = -1L;
+		User user = new User();
+
+		// when & then
+		InvalidValidationException ex = assertThrows(
+			InvalidValidationException.class,
+			()-> user.chargePoint(amount)
+		);
+		assertEquals(AMOUNT_SHOULD_BE_POSITIVE_NUMBER, ex.getMessage());
+	}
+	@Test
+	void 충전금액이_최소금액_미만이면_InvalidValidationException_예외발생() {
+		// given
+		long amount = 100L;
+		User user = new User();
+
+		// when & then
+		InvalidValidationException ex = assertThrows(
+			InvalidValidationException.class,
+			()-> user.chargePoint(amount)
+		);
+		assertEquals(CHARGE_AMOUNT_SHOULD_BE_MORE_THAN_MINIMUM, ex.getMessage());
+	}
+	@Test
+	void 충전금액이_최대값_보다_초과하면_InvalidValidationException_예외발생() {
+		// given
+		long amount = 100001L;
+		User user = new User();
+
+		// when & then
+		InvalidValidationException ex = assertThrows(
+			InvalidValidationException.class,
+			()-> user.chargePoint(amount)
+		);
+		assertEquals(CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM, ex.getMessage());
+	}
+	@Test
+	void 충전금액이_1000원이상_10000원이하면_충전에_성공한다() {
+		// given
+		long amount = 5000L;
+		User user = new User();
+
+		// when
+		long actualPoint = user.chargePoint(amount);
+
+		// then
+		assertEquals(actualPoint, 5000L);
+	}
+
+	@Test
+	void 사용금액이_0이하이면_InvalidValidationException_예외발생() {
+		// given
+		long amount = -1L;
+		User user = new User();
+
+		// when & then
+		InvalidValidationException ex = assertThrows(
+			InvalidValidationException.class,
+			()-> user.usePoint(amount)
+		);
+		assertEquals(AMOUNT_SHOULD_BE_POSITIVE_NUMBER, ex.getMessage());
+	}
+	@Test
+	void 사용금액이_보유포인트보다_많으면_InvalidValidationException_예외발생() {
+		// given
+		long amount = 500L;
+		User user = new User();
+
+		// when & then
+		InvalidValidationException ex = assertThrows(
+			InvalidValidationException.class,
+			()-> user.usePoint(amount)
+		);
+		assertEquals(LACK_OF_YOUR_POINT, ex.getMessage());
+	}
+	@Test
+	void 포인트_사용에_성공한다() {
+		// given
+		long amount = 1000L;
+		User user = new User();
+		user.chargePoint(5000L); // 포인트충전
+
+		// when
+		long actualPoint = user.usePoint(amount);
+
+		// then
+		assertEquals(actualPoint, 4000L);
+	}
+
+}


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- API 명세서: [API 명세서](https://app.swaggerhub.com/apis-docs/sampleswagger-f17/hh-08-concert/1.0.0)
- API 명세서 관련 커밋
  - API 엔드포인트 SwaggerHub 명세서 정의: 
    - 초안: 4a8a41ca6a3ab29ec3d22857580ccf8ce210958f 
    - API 별 엔드포인트 정의: 0ca1d921bb6a4f225de2bb85a4cb00872a0dbff8
    - 포인트/콘서트/예약 컨트롤러 리팩터링: 32aeec4a55ba305ca2b31a316ff7569d84b015eb
    - 도메인별 커스텀에러 생성 및 응답메시지 커스텀에러메시지로 리팩터링: bed0d63bb9b5ef5e650a0b351c7561bd1ae8e077
    - 이미 좌석예약시 409 Conflict 에러 정의/ 500 Internal Server Error 공통 에러정의: 4dc5e9d071ff74bd6687a6e1dc16543424434179
  
- API 목데이터 셋팅
      - 에러응답/정상응답 swagger 예시 목데이터 생성: ed97305b720552d5653697d9c0172129ef3ef0b4

---
### **리뷰 포인트(질문)**

> 리뷰 포인트 1
>

목데이터가 아래 이미지의 빨간색박스처럼 swagger UI의 example에 해당하는 걸까요?
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/2e47afcf-3131-44d2-9b6e-e21cbb291ebb" />


> 리뷰 포인트 2
>

저는 swagger을 작성하기위한 인터페이스에서 스웨거데코레이터를 정의한후에 이 스웨거 인터페이스를 Controller에 implement시키는 방안으로했습니다. 실무에서 swagger를 더 효율적으로 관리하는 방법이 있을까요?

- 스웨거 인터페이스

```java
// ReservationApiDocs.java

@Tag(name="Reservation")
public interface ReservationApiDocs {
	@Operation(summary = "좌석 예약 요청", description="좌석 예약 요청을 성공하면 5분간 임시배정 상태가 된다")
	@io.swagger.v3.oas.annotations.responses.ApiResponse(
		responseCode = "201",
		description = "CREATED",
		content= @Content(
			mediaType = "application/json",
			examples= @ExampleObject(
				name= "좌석 임시예약 성공 응답 예시",
				summary = "좌석 임시예약 성공 응답 데이터",
				value= """
					{
					  "status": 201,
					  "message": "CREATED",
					  "data": {
						"reservationId": 10001,
						"userId": 123,
						"concertId": 1,
						"concertDate": "2025-04-05",
						"seatId": 5001,
						"seatNo": 10,
						"price": 15000,
						"status": "PENDING_PAYMENT",
						"reservedAt": "2025-04-04T11:00:00",
						"tempReservationExpiredAt": "2025-04-04T11:05:00"
					  }
					}		
				"""
			)
		)
	)
	@io.swagger.v3.oas.annotations.responses.ApiResponse(
		responseCode = "400",
		description = "BAD_REQUEST",
		content = @Content(
			mediaType = "application/json",
			schema = @Schema(
				implementation = ErrorResponse.class),
			examples= {
				@ExampleObject(
					name=ID_SHOULD_BE_POSITIVE_NUMBER,
					summary = "id는 0보다 큰 양수이다",
					value = "{\"statusCode\":400,\"message\":\"" + ID_SHOULD_BE_POSITIVE_NUMBER + "\"}"
				),
			}
		)
	)
	@io.swagger.v3.oas.annotations.responses.ApiResponse(
		responseCode = "401",
		description = "UNAUTHORIZED",
		content = @Content(
			mediaType = "application/json",
			schema = @Schema(
				implementation = ErrorResponse.class),
				examples= @ExampleObject(
					value= "{\"status\":401,\"message\":\"토큰의 유효기간이 만료되었습니다.\"}"
			)
		)
	)
	public ResponseEntity<ApiResponse<ReservationResponse>> reserveTemporarySeat(@RequestHeader("token") String token, @RequestBody
	ReservationRequest request);
}

```

- 스웨거 인터페이스를 구현화
```java
@RestController
@RequestMapping("reservations")
@RequiredArgsConstructor
public class ReservationController implements  ReservationApiDocs {
	private final ReservationService reservationService;

	// 좌석 예약요청
	@PostMapping()
	public ResponseEntity<ApiResponse<ReservationResponse>> reserveTemporarySeat(@RequestHeader("token") String token, @RequestBody
		ReservationRequest request) {
		... 생략
	}
}

```

> 리뷰포인트 3
>

API 의 정상응답인 HTTP 코드는 ok(200), created (201) 인데요. 저의 경우에는 ResponseEntity<ApiResponse<응답DTO>> 식으로 리턴을 했으며, 응답데이터는 status/ message / data 형태로 구성되어있습니다. 응답데이터에는 data만 리턴하는것보다 메시지와 HTTP 응답코드를 나타냄으로써 응답형식을 통일화 했습니다.
제너릭이 너무 많아서... 조금 복잡해보이긴합니다. 정상응답반환 코드에 대한 리팩터링이 필요한지 피드백이 필요해보입니다.

- [ApiResponse](https://github.com/loveAlakazam/hh-08-concert/blob/step04/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponse.java)
- [ApiResponseEntity](https://github.com/loveAlakazam/hh-08-concert/blob/step04/src/main/java/io/hhplus/concert/interfaces/api/common/dto/ApiResponseEntity.java)


<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- 포기하지 말기. 나는 할 수 있다! 차근차근 하고있다!

### Problem
<!--개선이 필요한 점-->
- 정말 과제제출할 수 있을지...정말 아슬아슬하다... 지금 4/4(금) 새벽 4시50분인데 이제야 2단계를 시작한다....ㅠㅜㅜ
- 3일만에 설계과제를 해보려니... 많이 빡세다...ㅎ
- e2e까지 하고싶었는데... 이번주차는 필수구현위주로만 제출하고, 짬짬이 e2e도 해보는게 좋을거같다 ㅠ

### Try
<!-- 새롭게 시도할 점 -->
- ERD를 개선하고 wiki에 업로드해야될거같다.
- 앞으로 응답데이터를 조금 더 확인해봐야될거같다.
