### PR TITLE
[Step09] 서버구축 심화 기본과제

### DIFF
--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
@@ -18,6 +18,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,9 @@ public class ConcertSeat extends BaseEntity {
 
 	@Column(name="is_available", nullable = false)
 	private boolean isAvailable = true; // 예약가능여부
+
+	@Version
+	private int version; // 낙관적락
 
 
 	/**

--- a/src/main/java/io/hhplus/concert/domain/user/UserPointRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserPointRepository.java
@@ -7,4 +7,5 @@ public interface UserPointRepository {
 	UserPoint save(UserPoint userPoint);
 
 	void deleteAll();
+	UserPoint findUserPointWithExclusiveLock(long userId);
 }

--- a/src/main/java/io/hhplus/concert/domain/user/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserService.java
@@ -24,7 +24,7 @@ public class UserService {
     @Transactional
     public UserInfo.ChargePoint chargePoint(UserPointCommand.ChargePoint command) {
         // 유저 포인트정보 조회
-        UserPoint userPoint = userPointRepository.findByUserId(command.userId());
+        UserPoint userPoint = userPointRepository.findUserPointWithExclusiveLock(command.userId());
         if(userPoint == null)
             throw new BusinessException(UserErrorCode.NOT_EXIST_USER);
 
@@ -46,7 +46,7 @@ public class UserService {
     @Transactional
     public UserInfo.UsePoint usePoint(UserPointCommand.UsePoint command) {
         // 유저 정보 조회
-        UserPoint userPoint = userPointRepository.findByUserId(command.userId());
+        UserPoint userPoint = userPointRepository.findUserPointWithExclusiveLock(command.userId());
         if(userPoint == null) throw new BusinessException(UserErrorCode.NOT_EXIST_USER);
 
         // amount 값만큼 포인트 사용

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserPointJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserPointJpaRepository.java
@@ -4,14 +4,25 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import io.hhplus.concert.domain.user.UserPoint;
+import jakarta.persistence.LockModeType;
 
 public interface UserPointJpaRepository extends JpaRepository<UserPoint, Long> {
 
 	@EntityGraph(attributePaths = {"user", "histories"})
 	Optional<UserPoint> findByUserId(@Param("userId") long id);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		SELECT up
+		FROM UserPoint up
+			JOIN up.user u
+		WHERE u.id = :userId
+	""")
+	UserPoint findUserPointWithExclusiveLock(@Param("userId") long userId);
 }

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserPointRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserPointRepositoryImpl.java
@@ -1,6 +1,7 @@
 package io.hhplus.concert.infrastructure.persistence.user;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import io.hhplus.concert.domain.user.UserPoint;
 import io.hhplus.concert.domain.user.UserPointRepository;
@@ -24,5 +25,11 @@ public class UserPointRepositoryImpl implements UserPointRepository {
 	@Override
 	public void deleteAll() {
 		userPointJpaRepository.deleteAll();
+	}
+
+	@Override
+	@Transactional
+	public UserPoint findUserPointWithExclusiveLock(long userId) {
+		return userPointJpaRepository.findUserPointWithExclusiveLock(userId);
 	}
 }

--- a/src/test/java/io/hhplus/concert/TestcontainersConfiguration.java
+++ b/src/test/java/io/hhplus/concert/TestcontainersConfiguration.java
@@ -14,7 +14,7 @@ public class TestcontainersConfiguration {
 	public static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
 		.withDatabaseName("hhplus")
 			.withUsername("test")
-			.withPassword("test");;
+			.withPassword("test");
 
 	static  {
 		MYSQL_CONTAINER.start();
@@ -23,6 +23,8 @@ public class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
 		System.setProperty("spring.jpa.hibernate.ddl-auto", "create");
+		System.setProperty("spring.jpa.show-sql", "true");
+		System.setProperty("spring.jpa.properties.hibernate.format-sql", "true");
 	}
 
 	@PreDestroy

--- a/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
@@ -77,8 +77,9 @@ public class TemporaryReserveConcurrencyIntegrationTest {
 	@Test
 	void 서로다른_두명의_사용자가_동일한_좌석을_예약하려고할때_한명만_예약이_가능하다() throws InterruptedException {
 		// given
-		User user1 = User.of("최은강");
-		User user2 = User.of("최금강");
+		User user1 = userRepository.save(User.of("최은강"));
+		User user2 = userRepository.save(User.of("최금강"));;
+
 		ReservationCommand.TemporaryReserve command1 = ReservationCommand.TemporaryReserve.of(user1, sampleConcertSeat);
 		ReservationCommand.TemporaryReserve command2 = ReservationCommand.TemporaryReserve.of(user2, sampleConcertSeat);
 
@@ -112,6 +113,66 @@ public class TemporaryReserveConcurrencyIntegrationTest {
 					return false;
 				}
 			}).count();
+		assertEquals(1, successfulReservations, "오직 한명의 유저만 좌석 예약에 성공한다");
+	}
+	@Test
+	void 서로다른_사용자_10명이_동일한_좌석을_예약하려고할때_한명만_예약이_가능하다() throws InterruptedException {
+		// given
+		List<User> users = new ArrayList<>();
+		List<ReservationCommand.TemporaryReserve> commands = new ArrayList<>();
+		for(int i = 1; i <= 10 ; i++) {
+			User user = User.of("최은강 "+i);
+			users.add(userRepository.save(user));
+			commands.add(ReservationCommand.TemporaryReserve.of(user, sampleConcertSeat));
+		}
+		// when
+		int threadCount = users.size();
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		List<Future<ReservationInfo.TemporaryReserve>> results = new ArrayList<>();
+		commands.forEach(command -> {
+			Future<ReservationInfo.TemporaryReserve> commandResult = executorService.submit(() -> {
+				latch.countDown();
+				latch.await();
+				return reservationService.temporaryReserve(command);
+			});
+			results.add(commandResult);
+		});
+		executorService.shutdown();
+
+
+		// then
+		long successfulReservations = results.stream().filter(
+			temporaryReserveFuture -> {
+				try {
+					return temporaryReserveFuture.get() != null;
+				} catch (Exception e) {
+					return false;
+				}
+			}).count();
+
+		// 로그작성
+		for(int i = 0; i < results.size(); i++) {
+			User user = users.get(i);
+			Future<ReservationInfo.TemporaryReserve> future = results.get(i);
+			try {
+				ReservationInfo.TemporaryReserve info = future.get();
+				if (info != null) {
+					log.info("✅ 성공: {}(userId: {}) 님이 좌석을 예약하였습니다.", user.getName(), user.getId());
+				} else {
+					log.info("❌ 실패: {}(userId: {}) 님은 좌석예약에 실패하였습니다.", user.getName(), user.getId());
+				}
+
+			} catch(Exception e) {
+				log.warn("❌ 실패: {}(userId: {}) 님은 처리중 예외발생으로 예약에 실패했습니다. - 발생예외: {} - 메시지: {}",
+					user.getName(),
+					user.getId(),
+					e.getCause().getClass().getSimpleName(),
+					e.getMessage()
+				);
+			}
+		}
 		assertEquals(1, successfulReservations, "오직 한명의 유저만 좌석 예약에 성공한다");
 	}
 }

--- a/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/user/UserPointConcurrencyIntegrationTest.java
@@ -1,0 +1,96 @@
+package io.hhplus.concert.domain.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import io.hhplus.concert.TestcontainersConfiguration;
+import io.hhplus.concert.domain.concert.Concert;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Sql(statements = {
+	"SET FOREIGN_KEY_CHECKS=0",
+	"TRUNCATE TABLE user_points",
+	"TRUNCATE TABLE user_point_histories",
+	"TRUNCATE TABLE users",
+	"SET FOREIGN_KEY_CHECKS=1"
+}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class UserPointConcurrencyIntegrationTest {
+	@Autowired private UserService userService;
+	@Autowired private UserRepository userRepository;
+	@Autowired private UserPointRepository userPointRepository;
+	@Autowired private UserPointHistoryRepository userPointHistoryRepository;
+
+	User sampleUser;
+	UserPoint sampleUserPoint;
+	@BeforeEach
+	void setUp() {
+		// truncate -> serUp -> 테스트케이스 수행 순으로 진행
+		// 유저 테스트 데이터 셋팅
+		sampleUser = User.of("최은강");
+		userRepository.save(sampleUser);
+
+		sampleUserPoint = UserPoint.of(sampleUser); // 초기포인트 0 포인트
+		userPointRepository.save(sampleUserPoint);
+	}
+
+	@Test
+	@Order(1)
+	void 포인트_충전과_사용은_동시에_진행되어도_정합성이_깨지지_않아야_한다() throws Exception {
+		// given
+		long userId = sampleUser.getId();
+
+		// 먼저 10,000원 충전
+		userService.chargePoint(UserPointCommand.ChargePoint.of(userId, 10_000L));
+
+		// 두 작업이 동시에 실행되도록 조율하는 CyclicBarrier
+		CyclicBarrier barrier = new CyclicBarrier(2);
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		List<Future<Void>> results = new ArrayList<>();
+
+		// 충전 쓰레드
+		results.add(executor.submit(() -> {
+			barrier.await(); // 🔥 다른 스레드가 도달할 때까지 대기
+			userService.chargePoint(UserPointCommand.ChargePoint.of(userId, 5_000L));
+			return null;
+		}));
+
+		// 사용 쓰레드
+		results.add(executor.submit(() -> {
+			barrier.await(); // 🔥 두 스레드가 동시에 실행되도록 조율
+			userService.usePoint(UserPointCommand.UsePoint.of(userId, 5_000L));
+			return null;
+		}));
+
+		// when: 두 작업이 완료될 때까지 기다림
+		for (Future<Void> result : results) {
+			result.get(); // 예외 발생 시 여기서 잡힘
+		}
+
+		// then: 최종 포인트는 10,000 + 5,000 - 5,000 = 10,000
+		UserInfo.GetCurrentPoint info = userService.getCurrentPoint(UserPointCommand.GetCurrentPoint.of(userId));
+		assertEquals(10_000L, info.point());
+	}
+
+}


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->


**[동시성테스트 1] 서로다른 2명이 동시에 동일한 좌석을 예약했을때 1명만 성공한다 (최종: 낙관적락)**
낙관적락 적용 : [1a60c3c0](https://github.com/loveAlakazam/hh-08-concert/commit/1a60c3c0c4c5d4665cc18895805e162203b7613d)
비관적락/공유락(s-lock) 적용 : [b74126b](https://github.com/loveAlakazam/hh-08-concert/commit/b74126b47fee3f4ed2f6fc78d6fc1139f403fca5)
비관적락/배타락(x-lock) 적용 : [267cdcd](https://github.com/loveAlakazam/hh-08-concert/commit/267cdcda6ae7ce7d732add7f250b253f1e0c66f5)
🔒 **최종/낙관적락 적용** : 1a60c3c

<br>

**[동시성테스트 2] 포인트 충전과 사용은 동시에 호출되면 안된다 (최종: 배타락/ x-lock)**

낙관적락 사용: 40c1335
비관적락/공유락(s-lock) 사용: 334b48d
비관적락/배타락(x-lock) 사용: e7f8de4
🔒 **최종/배타락 적용**: f73408b

<br>

**락을 사용한 동시성제어 보고서**
보고서에는 각 동시성테스트에 대해서 어떤락이 적합한지에 대한 이유를 나타냈습니다.
보고서링크: [RDBMS 락을활용한 동시성제어 보고서](https://github.com/loveAlakazam/hh-08-concert/wiki/07_RDBMS_%EB%9D%BD%EC%9D%84%ED%99%9C%EC%9A%A9%ED%95%9C_%EB%8F%99%EC%8B%9C%EC%84%B1%EC%A0%9C%EC%96%B4%EB%B3%B4%EA%B3%A0%EC%84%9C)

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1 
동시성테스트케이스 상황에 맞추어 세가지 락을 적용해보고 비교해보는 실험을 해봤습니다.
보고서의 내용에서 제가 잘못이해한 내용이 있는지와 조금더 디깅(digging)이 필요한 부분을 알려주시면 감사하겠습니다 :)

- 추신: 4/18(금) 지난주 과제 리뷰를 위해 여기에 올려두겠습니다! 
맨상단에서 마우스스크롤하다보면 **리뷰포인트 질문 | OLD** 이전까지가 제가 보완한 내용들입니다.
  - [4주차 과제링크](https://github.com/loveAlakazam/hh-08-concert/pull/31)


<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)

본인이 어떤 시도를 했고 어떤이유로 그렇게 했는지 어떤부분이 궁금한지를 중심으로 질문!

  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
이론으로만 외우지말고 그 이론에서 나온 가정이 맞는지 재현해보려고함. (그런데 생각보다 많은 삽질이 있어서 ... 시간관리 정말잘해야함)

### Problem
<!--개선이 필요한 점-->
- 시간관리가 어렵다... : 조금더 깊이공부하려고 햇는데 너무 시간이 많이 소요되서 포기를 한적이 있다.
- 체력관리 :  운동을 안하고 눈뜸 -> 컴퓨터 -> 밤 -> 컴퓨터 -> 잠 순으로 되어있다.


### Try
<!-- 새롭게 시도할 점 -->
- x-lock과 s-lock 이 주는 사이드이펙트를 통합테스트케이스를 나타내려고 시도했지만 실패했다.... 조금더 락에대한 깊은 고민을 해보려고 시도한거같다. 조금더 제대로된 이해를 테스트케이스로 나타내고싶었는데 쉽지 않았다.

비관적락은 연산이 수행될때까지 대기를 하고, 낙관적락은 빠른 실패를 나타낸다고하는데 이를 테스트케이스로 보여주고싶었다.
그리고 공유락은 다른트랜잭션이 읽기수행이 가능하지만 쓰기를 동시에 요청할때 쓰기충돌이 발생한다. 여기까지는 알겠다. 여기서 더 나아가서 락을 가진 트랜잭션이 너무 오래동안 점유하고 있어서 다른 트랜잭션이 쓰기수행하려고할때 쓰기경합을 발생하는 상황을 테스트케이스로 나타내고싶었지만 실패를 했다.

비관적락은 둘다 다른트랜잭션이 해당 데이터로우에 대해서 수정을 하지 못하도록 막는다.
- s-lock(공유락)은 다른트랜잭션들도 해당데이터로우를 읽을수있다. 다른트랜잭션들도 읽기락을 얻을 수 있다. 즉 읽기는 허용한다. 
- x-lock(배타락)은 다른트랜잭션들은 읽기/쓰기가 제한되어있다. 락을 얻은 트랜잭션만 읽기/쓰기 접근이 가능하며 다른트랜잭션들은 기다려야한다. 이에 대한 사이드이펙트를 나타내고싶었으나 실패했다.
