### PR TITLE
Refactor: 5주차 피드백 리팩터링

### DIFF
--- a/src/main/java/io/hhplus/concert/ConcertApplication.java
+++ b/src/main/java/io/hhplus/concert/ConcertApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-// @EnableScheduling
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = "io.hhplus.concert.infrastructure.persistence")
 @EntityScan(basePackages = "io.hhplus.concert.domain")

--- a/src/main/java/io/hhplus/concert/application/usecase/token/TokenCriteria.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/token/TokenCriteria.java
@@ -2,6 +2,8 @@ package io.hhplus.concert.application.usecase.token;
 
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 
+import java.util.UUID;
+
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
 import io.hhplus.concert.interfaces.api.token.TokenRequest;
 
@@ -12,10 +14,10 @@ public record TokenCriteria(){
 			return new IssueWaitingToken(userId);
 		}
 	}
-	public record GetWaitingTokenPositionAndActivateWaitingToken(long userId) {
-		public static GetWaitingTokenPositionAndActivateWaitingToken of(long userId) {
-			if(userId <= 0) throw new InvalidValidationException(ID_SHOULD_BE_POSITIVE_NUMBER);
-			return new GetWaitingTokenPositionAndActivateWaitingToken(userId);
+	public record GetWaitingTokenPositionAndActivateWaitingToken(UUID uuid) {
+		public static GetWaitingTokenPositionAndActivateWaitingToken of(UUID uuid) {
+			if(uuid == null) throw new InvalidValidationException(NOT_NULLABLE);
+			return new GetWaitingTokenPositionAndActivateWaitingToken(uuid);
 		}
 	}
 }

--- a/src/main/java/io/hhplus/concert/application/usecase/token/TokenUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/token/TokenUsecase.java
@@ -22,6 +22,12 @@ public class TokenUsecase {
 	private final UserService userService;
 	private final TokenService tokenService;
 
+	/**
+	 * 사용자가 대기상태의 토큰발급 요청을 한다.
+	 *
+	 * @param criteria
+	 * @return TokenResult.IssueWaitingToken
+	 */
 	public TokenResult.IssueWaitingToken issueWaitingToken(TokenCriteria.IssueWaitingToken criteria) {
 		// 유저정보 조회
 		User user = userService.getUser(UserCommand.Get.of(criteria.userId()));
@@ -29,11 +35,21 @@ public class TokenUsecase {
 		TokenInfo.IssueWaitingToken info = tokenService.issueWaitingToken(TokenCommand.IssueWaitingToken.from(user));
 		return TokenResult.IssueWaitingToken.of(info, user);
 	}
+
+	/**
+	 * 대기번호 조회 요청 및 토큰활성화 로직
+	 * - 스케줄러를 통해서 폴링방식 구현.
+	 * - 대기번호가 1번인경우에는 토큰활성화 진행.
+	 * - 대기번호가 1이아니라면 대기번호상태를 나타냄.
+	 *
+	 * @param criteria
+	 * @return TokenResult.GetWaitingTokenPositionAndActivateWaitingToken
+	 */
 	public TokenResult.GetWaitingTokenPositionAndActivateWaitingToken getWaitingTokenPositionAndActivateWaitingToken(
 		TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken criteria)
 	{
-		// 토큰정보 조회
-		TokenInfo.GetTokenByUserId info = tokenService.getTokenByUserId(TokenCommand.GetTokenByUserId.of(criteria.userId()));
+		// UUID로 토큰정보 조회
+		TokenInfo.GetTokenByUUID info = tokenService.getTokenByUUID(TokenCommand.GetTokenByUUID.of(criteria.uuid()));
 		Token token = info.token();
 		if(token == null) throw new BusinessException(TOKEN_NOT_FOUND);
 
@@ -41,8 +57,11 @@ public class TokenUsecase {
 		int position = tokenService.getCurrentPosition(token.getUuid());
 
 		// 토큰의 대기상태번호가 1번이라면(대기열의 맨앞에 있으므로) 대기토큰을 활성화를 시킨다
-		if(position == 1)
-			tokenService.activateToken(TokenCommand.ActivateToken.of(token.getUuid()));
+		if(position == 1) {
+			TokenInfo.ActivateToken activateTokenInfo = tokenService.activateToken(TokenCommand.ActivateToken.of(token.getUuid()));
+			token = activateTokenInfo.token();
+			position = -1; // 이미 dequeue를 했으므로 -1로 변경한다.
+		}
 
 		return TokenResult.GetWaitingTokenPositionAndActivateWaitingToken.of(
 			token.getStatus(),

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
@@ -43,7 +43,7 @@ public class ConcertSeat extends BaseEntity {
 	private boolean isAvailable = true; // 예약가능여부
 
 	@Version
-	private int version; // 낙관적락
+	private long version; // 낙관적락
 
 
 	/**
@@ -72,6 +72,7 @@ public class ConcertSeat extends BaseEntity {
 		this.number = number;
 		this.price = price;
 		this.isAvailable = isAvailable;
+		this.version = 0L;
 	}
 	public static ConcertSeat of (Concert concert, ConcertDate concertDate, int number, long price, boolean isAvailable) {
 		if(concert == null) throw new BusinessException(NOT_NULLABLE);

--- a/src/main/java/io/hhplus/concert/domain/reservation/Reservation.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/Reservation.java
@@ -188,7 +188,7 @@ public class Reservation extends BaseEntity {
 		if(this.concertSeat.isAvailable()) return false;
 		// 에약 상태를 검증
 		// 좌석이 임시대기 상태인지확인
-		if(this.status != PENDING_PAYMENT)return false;
+		if(this.status != PENDING_PAYMENT) return false;
 		// 현재를 기준으로 좌석의 임시예약 만료일자가 아직 유효한지
 		if(DateValidator.isPastDateTime(this.tempReservationExpiredAt)) return false;
 		return true;
@@ -198,5 +198,16 @@ public class Reservation extends BaseEntity {
 		if(this.status != CONFIRMED) return false;
 		if(this.reservedAt == null) return false;
 		return true;
+	}
+
+	/**
+	 * 문제점: 만료를 재현시키다보니 테스트에서도 만료될때까지 기다려야되는 문제발생.
+	 * 만료일자를 지정하여 인스턴스함수로 만료상태로 변경하고자한다.
+	 */
+	public void expireTemporaryReserve(LocalDateTime expiredAt) {
+		if(!DateValidator.isPastDateTime(expiredAt))
+			throw new InvalidValidationException(EXPIRED_DATE_SHOULD_BE_PAST_DATETIME);
+		this.tempReservationExpiredAt = expiredAt;
+
 	}
 }

--- a/src/main/java/io/hhplus/concert/domain/token/TokenCommand.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenCommand.java
@@ -17,7 +17,7 @@ public record TokenCommand() {
 	}
 	public record GetTokenByUUID(UUID uuid) {
 		public static GetTokenByUUID of(UUID uuid) {
-			if(uuid != null) throw new InvalidValidationException(SHOULD_NOT_EMPTY);
+			if(uuid == null) throw new InvalidValidationException(SHOULD_NOT_EMPTY);
 			return new GetTokenByUUID(uuid);
 		}
 	}

--- a/src/main/java/io/hhplus/concert/domain/token/TokenScheduler.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenScheduler.java
@@ -6,4 +6,7 @@ public interface TokenScheduler {
 
 	// 대기열큐에서 대기중인 토큰중 만료된 토큰들은 삭제한다 (매 5분마다)
 	void removeExpiredWaitingTokensInWaitingQueue();
+
+	// 매 10초마다 폴링방식으로 대기상태토큰의 대기번호조회 및 토큰활성화
+	void pollWaitingTokens();
 }

--- a/src/main/java/io/hhplus/concert/domain/token/TokenService.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenService.java
@@ -10,9 +10,12 @@ import io.hhplus.concert.domain.user.User;
 import io.hhplus.concert.domain.user.UserRepository;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenService {
@@ -76,7 +79,7 @@ public class TokenService {
         // 이미 토큰이 activated 됐는지 확인
         if(token.isActivated()) throw new BusinessException(TOKEN_ALREADY_ISSUED);
         // 대기열큐에 존재하며, 대상토큰의 uuid가 대기열큐의 맨앞에있는지 확인
-        if( waitingQueue.contains(uuid) && (uuid != waitingQueue.peek()) )
+        if( waitingQueue.contains(uuid) && waitingQueue.peek() == uuid )
             throw new BusinessException(TOKEN_IS_WAITING);
 
         // 해당 uuid 를 큐에서 제거

--- a/src/main/java/io/hhplus/concert/domain/user/UserPointHistory.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserPointHistory.java
@@ -53,7 +53,7 @@ public class UserPointHistory extends BaseEntity {
 
     /**
      * 정적 팩토리 메소드로 포인트히스토리 추가
-     * @param user
+     * @param userPoint
      * @param amount
      * @param status
      * @return UserPointHistory

--- a/src/main/java/io/hhplus/concert/domain/user/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserService.java
@@ -71,7 +71,7 @@ public class UserService {
     }
 
     public UserInfo.GetUserPoint getUserPoint(UserPointCommand.GetUserPoint command) {
-        UserPoint userPoint = userPointRepository.findByUserId(command.userId());
+        UserPoint userPoint = userPointRepository.findUserPointWithExclusiveLock(command.userId());
         if(userPoint == null) throw new BusinessException(UserErrorCode.NOT_EXIST_USER);
         return UserInfo.GetUserPoint.of(userPoint);
     }

--- a/src/main/java/io/hhplus/concert/infrastructure/scheduler/TokenSchedulerImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/scheduler/TokenSchedulerImpl.java
@@ -6,13 +6,18 @@ import java.util.UUID;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import io.hhplus.concert.application.usecase.token.TokenCriteria;
+import io.hhplus.concert.application.usecase.token.TokenUsecase;
 import io.hhplus.concert.domain.token.TokenMaintenanceService;
 import io.hhplus.concert.domain.token.TokenScheduler;
+import io.hhplus.concert.domain.token.WaitingQueue;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class TokenSchedulerImpl implements TokenScheduler {
+	private final WaitingQueue waitingQueue;
+	private final TokenUsecase tokenUsecase;
 	private final TokenMaintenanceService tokenMaintenanceService;
 
 	@Scheduled(cron = "0 0 0 * * *")
@@ -25,5 +30,20 @@ public class TokenSchedulerImpl implements TokenScheduler {
 	@Override
 	public void removeExpiredWaitingTokensInWaitingQueue() {
 		tokenMaintenanceService.removeExpiredWaitingTokensInWaitingQueue();
+	}
+
+	@Scheduled(cron = "*/10 * * * * *")
+	@Override
+	public void pollWaitingTokens() {
+		List<UUID> uuids = waitingQueue.toList();
+		
+		// 상위100개만을 폴링방식으로 호출하여 토큰을 활성화시킨다.
+		if(uuids.size() >= 100 ) uuids = uuids.subList(0, 100);
+
+		for(UUID uuid : uuids) {
+			tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
+				TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(uuid)
+			);
+		}
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/LoggingInterceptor.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/LoggingInterceptor.java
@@ -1,0 +1,34 @@
+package io.hhplus.concert.interfaces.api.common;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+	private static final String START_TIME = "start_time";
+
+	@Override
+	public boolean preHandle(HttpServletRequest request,  HttpServletResponse response, Object handler) {
+		long startTime = System.currentTimeMillis();
+		request.setAttribute(START_TIME, startTime);
+		log.info(":::: [REQUEST] {} {} from IP {}", request.getMethod(), request.getRequestURI(), request.getRemoteAddr());
+		log.info(":::: [HEADER] token={}", request.getHeader("token")); // 토큰 로깅
+		return true;
+	}
+	@Override
+	public void afterCompletion(HttpServletRequest request,  HttpServletResponse response, Object handler, Exception ex) {
+		long startTime = (Long) request.getAttribute(START_TIME);
+		long endTime = System.currentTimeMillis();
+		long duration = endTime - startTime;
+
+		log.info(":::: [RESPONSE] {} {} Status={} Duration={}ms", request.getMethod(), request.getRequestURI(), response.getStatus(), duration);
+
+		if(ex != null)
+			log.info(":::: [EXCEPTION] ", ex);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/ReservationErrorCode.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/ReservationErrorCode.java
@@ -15,6 +15,7 @@ public enum ReservationErrorCode implements BusinessErrorCode {
 	 ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 좌석은 이미 예약이 되었습니다."),
 	 NOT_FOUND_RESERVATION(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다"),
 	 INVALID_RESERVATION_STATUS (HttpStatus.BAD_REQUEST, "적합하지 않은 상태정보 입니다"),
+	 EXPIRED_DATE_SHOULD_BE_PAST_DATETIME (HttpStatus.BAD_REQUEST, "만료일자는 반드시 과거날짜여야 합니다."),
 	 INVALID_INPUT_DATA( HttpStatus.BAD_REQUEST, "입력데이터가 적절하지 않습니다."),
 	 TEMPORARY_RESERVATION_ALREADY_EXPIRED(
 		 HttpStatus.REQUEST_TIMEOUT, "유효시간 "+TEMPORARY_RESERVATION_DURATION_MINUTE+"분이 이미 지났으므로, 해당 예약은 이미 만료되었습니다"

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/TokenController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/TokenController.java
@@ -40,7 +40,7 @@ public class TokenController implements TokenApiDocs {
 	) {
 		TokenResult.GetWaitingTokenPositionAndActivateWaitingToken result =
 			tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
-				TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(request.userId())
+				TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(request.uuid())
 			);
 		return ApiResponseEntity.ok(TokenResponse.GetWaitingTokenPositionAndActivateWaitingToken.of(result));
 	}

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/TokenHandlerInterceptor.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/TokenHandlerInterceptor.java
@@ -4,6 +4,7 @@ import static io.hhplus.concert.interfaces.api.token.TokenErrorCode.*;
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -27,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TokenHandlerInterceptor implements HandlerInterceptor {
 	private final TokenService tokenService;
+	private final ObjectMapper objectMapper;
 
 
 	@Override
@@ -60,13 +62,9 @@ public class TokenHandlerInterceptor implements HandlerInterceptor {
 		response.setStatus(status.value());
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		response.setCharacterEncoding("UTF-8");
-		String body = """
-			{
-				"status": %d,
-				"message": "%s"
-			}
-			""".formatted(status.value(), message);
-		response.getWriter().write(body);
 
+		ErrorResponse errorResponse = ErrorResponse.of(status.value(), message);
+		String json = objectMapper.writeValueAsString(errorResponse);
+		response.getOutputStream().write(json.getBytes(StandardCharsets.UTF_8));
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/TokenRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/TokenRequest.java
@@ -10,9 +10,9 @@ public record TokenRequest() {
 			return new IssueWaitingToken(userId);
 		}
 	}
-	public record GetWaitingTokenPositionAndActivateWaitingToken(long userId) {
-		public static GetWaitingTokenPositionAndActivateWaitingToken of(long userId, UUID uuid) {
-			return new GetWaitingTokenPositionAndActivateWaitingToken(userId);
+	public record GetWaitingTokenPositionAndActivateWaitingToken(UUID uuid) {
+		public static GetWaitingTokenPositionAndActivateWaitingToken of(UUID uuid) {
+			return new GetWaitingTokenPositionAndActivateWaitingToken(uuid);
 		}
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/WebMvcConfig.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/WebMvcConfig.java
@@ -14,16 +14,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import io.hhplus.concert.interfaces.api.common.ErrorResponse;
+import io.hhplus.concert.interfaces.api.common.LoggingInterceptor;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 	private final TokenHandlerInterceptor tokenInterceptor;
+	private final LoggingInterceptor loggingInterceptor;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
+		// 로깅인터셉터
+		registry.addInterceptor(loggingInterceptor)
+			.order(1)
+			.addPathPatterns("/**");
+
+		// 토큰인터셉터
 		registry.addInterceptor(tokenInterceptor)
+			.order(2)
 			.addPathPatterns("/**") // 전체 대상
 			.excludePathPatterns("/concerts/**", "/tokens/**", "/users/account"); // 해당 API 는 인터셉터 검증을 제외한다
 	}

--- a/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
@@ -118,9 +118,11 @@ public class PayAndConfirmTest {
 
 		long reservationId = 1L;
 		Reservation reservation = Reservation.of(user,concert,concertDate, concertSeat);
-		reservation.temporaryReserve(); // 임시예약상태
-		log.info("6분 대기하여 예약기간이 만료되어 취소처리됨");
-		Thread.sleep(6 * 60 * 1000);
+		// 임시예약상태
+		reservation.temporaryReserve();
+		// 임시예약상태를 만료시킨다.
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+
 		reservation.cancel(); // 취소처리
 		ReservationCommand.Get getReservationCommand = ReservationCommand.Get.of(reservationId);
 		when(reservationService.get(getReservationCommand)).thenReturn(ReservationInfo.Get.from(reservation));

--- a/src/test/java/io/hhplus/concert/application/usecase/reservation/ReservationUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/reservation/ReservationUsecaseIntegrationTest.java
@@ -70,7 +70,7 @@ public class ReservationUsecaseIntegrationTest {
 	User sampleUser;
 	@BeforeEach
 	void setUp() {
-		// truncate -> serUp -> 테스트케이스 수행 순으로 진행
+		// truncate -> setUp -> 테스트케이스 수행 순으로 진행
 		// 유저 테스트 데이터 셋팅
 		sampleUser = User.of("최은강");
 		userRepository.save(sampleUser);

--- a/src/test/java/io/hhplus/concert/application/usecase/token/TokenUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/token/TokenUsecaseIntegrationTest.java
@@ -1,0 +1,163 @@
+package io.hhplus.concert.application.usecase.token;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import io.hhplus.concert.TestcontainersConfiguration;
+import io.hhplus.concert.domain.token.Token;
+import io.hhplus.concert.domain.token.TokenRepository;
+import io.hhplus.concert.domain.token.TokenService;
+import io.hhplus.concert.domain.token.TokenStatus;
+import io.hhplus.concert.domain.token.WaitingQueue;
+import io.hhplus.concert.domain.user.User;
+import io.hhplus.concert.domain.user.UserRepository;
+import io.hhplus.concert.domain.user.UserService;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Sql(statements = {
+	"SET FOREIGN_KEY_CHECKS=0",
+	"TRUNCATE TABLE tokens",
+	"TRUNCATE TABLE users",
+	"SET FOREIGN_KEY_CHECKS=1"
+}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TokenUsecaseIntegrationTest {
+	@Autowired private TokenUsecase tokenUsecase;
+	@Autowired private TokenService tokenService;
+	@Autowired private UserService userService;
+
+	@Autowired private UserRepository userRepository;
+	@Autowired private TokenRepository tokenRepository;
+	@Autowired private WaitingQueue waitingQueue;
+
+	UUID sampleUserUUID;
+	User sampleUser;
+	Token sampleWaitingToken;
+
+	@BeforeEach
+	void setUp() {
+		// truncate -> setUp -> 테스트케이스 수행순으로 진행
+		// 대기 토큰을 비운다
+		waitingQueue.clear();
+
+		// 테스트 유저 데이터 초기셋팅
+		sampleUser = userRepository.save(User.of("테스트 유저"));
+	}
+
+	/**
+	 * issueWaitingToken
+	 */
+	@Order(1)
+	@Test
+	void 신규_대기상태토큰_발급을_요청한다() {
+		// when
+		TokenResult.IssueWaitingToken tokenResult = tokenUsecase.issueWaitingToken(TokenCriteria.IssueWaitingToken.of(sampleUser.getId()));
+
+		// then
+		assertNotNull(tokenResult.token()); // 응답값의 토큰은 null이 아니다.
+		assertNotNull(tokenResult.user()); // 응답값의 유저는 null이 아니다.
+
+		assertEquals(sampleUser.getName(), tokenResult.token().getUser().getName()); // 응답값의 유저는 테스트유저이다.
+
+		assertEquals(1, tokenResult.position());// 대기열큐의 1번이다.
+		assertTrue(waitingQueue.contains(tokenResult.token().getUuid())); // 대기열큐에 uuid가 들어있음
+		assertEquals(TokenStatus.WAITING, tokenResult.token().getStatus());// 토큰의 현재상태는 대기상태이다.
+		assertFalse(tokenResult.token().isExpiredToken());// 토큰의 현재상태는 만료되지않았으며 아직 유효하다
+		assertFalse(tokenResult.token().isActivated()); // 토큰은 활성화되지 않았다.
+	}
+	@Order(2)
+	@Test
+	void 큐에없으며_이미_만료된_대기상태토큰을_가지고있을때_대기상태_토큰발급요청시_다시_대기상태의_토큰으로_전환된다() {
+		// given
+		// 큐에는 들어있지 않으며, 이미 만료된토큰을 가지고있다고 가정
+		sampleUserUUID = UUID.randomUUID();
+		Token token = Token.of(sampleUser, sampleUserUUID);
+		token.expire(LocalDateTime.now().minusSeconds(1)); // 이미 토큰은 만료되었음
+		tokenRepository.saveOrUpdate(token); // 영속성컨텍스트에 반영
+
+		// when
+		TokenResult.IssueWaitingToken tokenResult = tokenUsecase.issueWaitingToken(TokenCriteria.IssueWaitingToken.of(sampleUser.getId()));
+
+		// then
+		assertNotNull(tokenResult.token()); // 응답값의 토큰은 null이 아니다.
+		assertNotNull(tokenResult.user()); // 응답값의 유저는 null이 아니다.
+
+		assertEquals(sampleUser.getName(), tokenResult.token().getUser().getName()); // 응답값의 유저는 테스트유저이다.
+
+		assertEquals(1, tokenResult.position());// 대기열큐의 1번이다.
+		assertTrue(waitingQueue.contains(tokenResult.token().getUuid())); // 대기열큐에 uuid가 들어있음
+		assertEquals(TokenStatus.WAITING, tokenResult.token().getStatus());// 토큰의 현재상태는 대기상태이다.
+		assertFalse(tokenResult.token().isExpiredToken());// 토큰의 현재상태는 만료되지않았으며 아직 유효하다
+		assertFalse(tokenResult.token().isActivated()); // 토큰은 활성화되지 않았다.
+	}
+
+	/**
+	 * getWaitingTokenPositionAndActivateWaitingToken
+	 */
+	@Order(3)
+	@Test
+	void 대기토큰의_대기열큐의_대기순서번호가_1번이라면_활성화시킨후에_토큰상태를_응답한다() {
+		// given
+		long userId = sampleUser.getId();
+		// 토큰발급
+		TokenResult.IssueWaitingToken tokenResult = tokenUsecase.issueWaitingToken(
+			TokenCriteria.IssueWaitingToken.of(userId)
+		);
+		assertEquals(1, tokenResult.position()); // 대기열에 sampleUser의 토큰만 있으므로 대기순서는 1번이다.
+		assertEquals(TokenStatus.WAITING, tokenResult.token().getStatus()); // sampleUser의 토큰의 상태는 대기상태이다.
+		assertEquals(waitingQueue.peek(), tokenResult.token().getUuid()); // 대기큐의 맨앞의 uuid는 sampleUser 토큰의 uuid 이다
+		UUID uuid = tokenResult.token().getUuid();
+
+		// when
+		TokenResult.GetWaitingTokenPositionAndActivateWaitingToken result = tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
+			TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(uuid)
+		);
+
+		// then
+		assertEquals(TokenStatus.ACTIVE, result.status()); // 활성화상태이다.
+		assertFalse(waitingQueue.contains(result.uuid())); // 이미활성화된 토큰의 uuid는 대기열큐에 존재하지 않는다.
+		assertEquals(-1, result.position()); // 이미 대기열큐에서 dequeue 되어 활성화시켰으므로 대기번호는 의미없다.
+	}
+	@Order(4)
+	@Test
+	void 대기토큰의_대기열큐의_대기순서번호가_1번이_아니라면_토큰상태만_응답한다() {
+		// given
+		// 대기열의 순서가 firstUser.uuid -> sampleUser.uuid 순으로되어있어서
+		// firstUser의 대기번호는 대기열큐의 1번째 순서로 되어있음.
+		User firstUser = userRepository.save(User.of("다른유저"));
+		long firstUserId = firstUser.getId();
+		TokenResult.IssueWaitingToken firstUserTokenResult = tokenUsecase.issueWaitingToken(
+			TokenCriteria.IssueWaitingToken.of(firstUserId)
+		);
+		// sampleUser의 대기번호는 대기열큐의 2번째순서로 되어있음.
+		long sampleUserId = sampleUser.getId();
+		TokenResult.IssueWaitingToken sampleUserTokenResult = tokenUsecase.issueWaitingToken(
+			TokenCriteria.IssueWaitingToken.of(sampleUserId)
+		);
+		sampleUserUUID = sampleUserTokenResult.token().getUuid();
+		assertEquals(2, waitingQueue.getPosition(sampleUserUUID));
+
+		// when
+		TokenResult.GetWaitingTokenPositionAndActivateWaitingToken result = tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
+			TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(sampleUserUUID)
+		);
+		// then
+		assertEquals(TokenStatus.WAITING, result.status()); // 대기열큐의 대기순서가 2번째라면 아직 대기상태이다.
+		assertTrue(waitingQueue.contains(result.uuid())); // 이미활성화된 토큰의 uuid는 대기열큐에 존재한다
+		assertEquals(2, result.position()); // 대기열큐에 2번째에 위치한다
+
+	}
+}

--- a/src/test/java/io/hhplus/concert/domain/payment/PaymentAndConfirmConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/payment/PaymentAndConfirmConcurrencyIntegrationTest.java
@@ -1,0 +1,178 @@
+package io.hhplus.concert.domain.payment;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDate;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import io.hhplus.concert.TestcontainersConfiguration;
+import io.hhplus.concert.application.usecase.payment.PaymentCriteria;
+import io.hhplus.concert.application.usecase.payment.PaymentResult;
+import io.hhplus.concert.application.usecase.payment.PaymentUsecase;
+import io.hhplus.concert.domain.concert.Concert;
+import io.hhplus.concert.domain.concert.ConcertDate;
+import io.hhplus.concert.domain.concert.ConcertDateRepository;
+import io.hhplus.concert.domain.concert.ConcertRepository;
+import io.hhplus.concert.domain.concert.ConcertSeat;
+import io.hhplus.concert.domain.concert.ConcertSeatRepository;
+import io.hhplus.concert.domain.reservation.Reservation;
+import io.hhplus.concert.domain.reservation.ReservationCommand;
+import io.hhplus.concert.domain.reservation.ReservationInfo;
+import io.hhplus.concert.domain.reservation.ReservationRepository;
+import io.hhplus.concert.domain.reservation.ReservationService;
+import io.hhplus.concert.domain.reservation.ReservationStatus;
+import io.hhplus.concert.domain.user.User;
+import io.hhplus.concert.domain.user.UserInfo;
+import io.hhplus.concert.domain.user.UserPoint;
+import io.hhplus.concert.domain.user.UserPointCommand;
+import io.hhplus.concert.domain.user.UserPointRepository;
+import io.hhplus.concert.domain.user.UserRepository;
+import io.hhplus.concert.domain.user.UserService;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Sql(statements = {
+	"SET FOREIGN_KEY_CHECKS=0",
+	"TRUNCATE TABLE payments",
+	"TRUNCATE TABLE reservations",
+	"TRUNCATE TABLE concert_seats",
+	"TRUNCATE TABLE concert_dates",
+	"TRUNCATE TABLE concerts",
+	"TRUNCATE TABLE user_point_histories",
+	"TRUNCATE TABLE user_points",
+	"TRUNCATE TABLE users",
+	"SET FOREIGN_KEY_CHECKS=1"
+}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class PaymentAndConfirmConcurrencyIntegrationTest {
+	@Autowired private PaymentUsecase paymentUsecase;
+	@Autowired private PaymentService paymentService;
+	@Autowired private ReservationService reservationService;
+	@Autowired private UserService userService;
+
+	@Autowired private PaymentRepository paymentRepository;
+	@Autowired private ReservationRepository reservationRepository;
+	@Autowired private UserRepository userRepository;
+	@Autowired private UserPointRepository userPointRepository;
+
+	@Autowired private ConcertRepository concertRepository;
+	@Autowired private ConcertDateRepository concertDateRepository;
+	@Autowired private ConcertSeatRepository concertSeatRepository;
+	private static final Logger log = LoggerFactory.getLogger(PaymentAndConfirmConcurrencyIntegrationTest.class);
+
+
+	/**
+	 * [동시성테스트] 동일한 회원이 여러개의 예약좌석 확정 및 결제를 동시에 진행한다.
+	 * (일정A, 좌석1번, 15000원), (일정B, 좌석11번, 10000원) => 둘다 임시예약상태(임시5분동안 좌석은 점유됨)
+	 * 여기서 공유자원은 무엇일까? => 회원의 포인트
+	 * - 좌석은 여러가지이고 상태값외로는 데이터변경자체가 없는편이다. 각 좌석은 낙관적락을 사용하고있고
+	 * - 포인트 충전/사용의 경우에는 비관적락(x-lock)을 사용함. 왜냐면 포인트는 의도적인 변경에 민감하며, 돈과 직결되므로 데이터의 정합성이 우선시함.
+	 */
+	User sampleUser;
+	UserPoint sampleUserPoint;
+
+	Concert sampleConcert1;
+	ConcertDate sampleConcertDate1;
+	ConcertSeat sampleConcertSeat1;
+
+	Concert sampleConcert2;
+	ConcertDate sampleConcertDate2;
+	ConcertSeat sampleConcertSeat2;
+
+	@BeforeEach
+	void setUp() {
+		// truncate -> setUp -> 테스트케이스 수행순으로 이뤄지고 있음.
+		// 유저 & 유저포인트 테스트 데이터 셋팅
+		sampleUser = User.of("최은강");
+		userRepository.save(sampleUser);
+		userPointRepository.save(UserPoint.of(sampleUser)); // 초기포인트 0 포인트
+
+		// 콘서트 테스트 데이터 셋팅
+		// 콘서트 1
+		sampleConcert1 = concertRepository.saveOrUpdate(Concert.create(
+			"테스트를 우선시하는 TDD 콘서트",
+			"TDD",
+			LocalDate.now(),
+			"서울시 성동구 연무장길",
+			10000
+		));
+		sampleConcertDate1 = sampleConcert1.getDates().get(0);
+		sampleConcertSeat1 = sampleConcertDate1.getSeats().get(0);
+
+		// 콘서트 2
+		sampleConcert2 = concertRepository.saveOrUpdate(Concert.create(
+			"통합테스트와 함께하는 TDD 콘서트",
+			"통합테스트",
+			LocalDate.now().plusWeeks(2),
+			"서울시 성동구 왕십리 광장",
+			5000
+		));
+		sampleConcertDate2 = sampleConcert2.getDates().get(0);
+		sampleConcertSeat2 = sampleConcertDate2.getSeats().get(0);
+	}
+	@Test
+	@Order(1)
+	@Sql(statements = {
+		"SET SESSION innodb_lock_wait_timeout=10"
+	}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+	@Sql(statements = {
+		"SET SESSION innodb_lock_wait_timeout=50"
+	}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+	void 회원이_동시에_여러개의_임시예약을_결제한다() throws ExecutionException, InterruptedException {
+		// given
+		long userId = sampleUser.getId();
+		// 먼저 2만원 충전
+		userService.chargePoint(UserPointCommand.ChargePoint.of(userId, 20_000L));
+
+		// 2개의 예약 셋팅
+		// 예약 1
+		ReservationInfo.TemporaryReserve temporaryReserveInfo1 = reservationService.temporaryReserve(ReservationCommand.TemporaryReserve.of(
+			sampleUser, sampleConcertSeat1
+		));
+		Reservation reservation1 = temporaryReserveInfo1.reservation();
+		long reservationId1 = reservation1.getId();
+		PaymentCriteria.PayAndConfirm paymentCriteria1 = PaymentCriteria.PayAndConfirm.of(userId, reservationId1);
+
+		// 예약 2
+		ReservationInfo.TemporaryReserve temporaryReserveInfo2 = reservationService.temporaryReserve(ReservationCommand.TemporaryReserve.of(
+			sampleUser, sampleConcertSeat2
+		));
+		Reservation reservation2 = temporaryReserveInfo2.reservation();
+		long reservationId2 = reservation2.getId();
+		PaymentCriteria.PayAndConfirm paymentCriteria2 = PaymentCriteria.PayAndConfirm.of(userId, reservationId2);
+
+		// when
+		// 결제 동시성테스트
+		CompletableFuture<PaymentResult.PayAndConfirm> future1 = CompletableFuture.supplyAsync(() -> paymentUsecase.payAndConfirm(paymentCriteria1));
+		CompletableFuture<PaymentResult.PayAndConfirm> future2 = CompletableFuture.supplyAsync(() -> paymentUsecase.payAndConfirm(paymentCriteria2));
+		CompletableFuture.allOf(future1, future2).join(); // 둘다 완료할 때까지 대기
+
+		PaymentResult.PayAndConfirm result1 = future1.get();
+		PaymentResult.PayAndConfirm result2 = future2.get();
+
+		// then
+		assertThat(result1.payment().getReservation()).isNotNull();
+		assertThat(result2.payment().getReservation()).isNotNull();
+
+		// 두개의 예약이모두 확정상태인지 확인
+		assertThat(result1.payment().getReservation().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		assertThat(result2.payment().getReservation().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+		// 포인트가 정상차감됐는지 확인: 20,000원 - (10,000원 + 5,000원) = 5,000원
+		UserInfo.GetUserPoint userPointInfo = userService.getUserPoint(UserPointCommand.GetUserPoint.of(userId));
+		assertThat(userPointInfo.userPoint().getPoint()).isEqualTo(5_000L);
+	}
+}

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationEntityTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationEntityTest.java
@@ -7,6 +7,7 @@ import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -183,9 +184,9 @@ public class ReservationEntityTest {
 		assertNull(reservation.getReservedAt()); // 임시예약상태 - 예약확정일자 없음
 		assertEquals(true, reservation.isTemporary()); // 임시예약상태
 
-		// 임시예약상태로 6분간 sleep 한다
-		log.info("6분간 sleep 상태로 대기");
-		Thread.sleep(6 * 60 * 1000);
+		// 임시예약 기간이 만료된다
+		log.info("임시예약일자 만료");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 		assertTrue( DateValidator.isPastDateTime(reservation.getTempReservationExpiredAt()) );
 
 		// when

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceServiceTest.java
@@ -50,9 +50,11 @@ public class ReservationMaintenanceServiceTest {
         ConcertSeat concertSeat = concertDate.getSeats().get(0);
 
         Reservation reservation = Reservation.of(user,concert, concertDate, concertSeat);
-        reservation.temporaryReserve();// 임시에약상태로 변경
-        log.info(":: 임시예약 만료가 될때까지 5분 대기");
-        Thread.sleep(5 * 60 * 1000 + 1);
+        // 임시에약상태로 변경
+        reservation.temporaryReserve();
+        // 임시예약상태를 만료
+        log.info("임시예약 유효기간이 만료됨");
+        reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 
         List<Reservation> expiredReservations = List.of(reservation);
 

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -279,11 +280,12 @@ public class ReservationServiceIntegrationTest {
 		assertNotNull(reservation);
 		assertTrue(reservation.isTemporary()); // 임시예약상태
 		long reservationId = reservation.getId();
-		log.info("5분 + 1ms 대기");
-		Thread.sleep(TEMPORARY_RESERVATION_DURATION_MILLISECOND + 1);
 
 		log.info("임시예약이 만료됨");
-		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()));
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+		reservationRepository.saveOrUpdate(reservation);
+		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()), "만료일자는 이미 지나간 날짜임을 확인");
+
 		// when & then
 		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
 		BusinessException exception = assertThrows(
@@ -309,11 +311,12 @@ public class ReservationServiceIntegrationTest {
 		assertNotNull(reservation);
 		assertTrue(reservation.isTemporary()); // 임시예약상태
 		long reservationId = reservation.getId();
-		log.info("5분 + 1ms 대기");
-		Thread.sleep(TEMPORARY_RESERVATION_DURATION_MILLISECOND + 1);
 
 		log.info("임시예약이 만료됨");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+		reservationRepository.saveOrUpdate(reservation);
 		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()));
+
 		// when & then
 		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
 		ReservationInfo.Cancel cancelInfo = assertDoesNotThrow(

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,9 +81,10 @@ public class ReservationServiceTest {
 		assertDoesNotThrow(()-> reservation.temporaryReserve());
 		assertTrue(reservation.isTemporary());
 
-		log.info("6분간 대기");
-		Thread.sleep(6 * 60* 1000); // 6분이 지나서 임시예약 유효기간이 만료
-		log.info("임시예약이 유효일자가 만료되어 취소상태로 변경");
+		log.info("임시예약만료일자가 만료됨");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+
+		log.info("임시예약이 만료되어 취소상태로 변경");
 		assertDoesNotThrow(() -> reservation.cancel()); // 임시예약상태로 변경
 
 		when(reservationRepository.findByConcertSeatIdAndUserId(anyLong(), anyLong())).thenReturn(reservation);
@@ -110,8 +112,8 @@ public class ReservationServiceTest {
 		assertDoesNotThrow(()-> reservation.temporaryReserve());
 		assertTrue(reservation.isTemporary());
 
-		log.info("6분간 대기");
-		Thread.sleep(6 * 60* 1000); // 6분이 지나서 임시예약 유효기간이 만료
+		log.info("임시예약 유효기간 만료");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 
 		when( reservationRepository.findById( reservationId )).thenReturn(reservation);
 		// when
@@ -136,8 +138,8 @@ public class ReservationServiceTest {
 		assertDoesNotThrow(()-> reservation.temporaryReserve());
 		assertTrue(reservation.isTemporary());
 
-		log.info("6분간 대기");
-		Thread.sleep(6 * 60* 1000); // 6분이 지나서 임시예약 유효기간이 만료
+		log.info("임시예약 유효기간이 만료됨");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 
 		log.info("임시예약이 유효일자가 만료되어 취소상태로 변경");
 		assertDoesNotThrow(() -> reservation.cancel()); // 임시예약상태로 변경

--- a/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
@@ -38,6 +38,8 @@ import io.hhplus.concert.domain.user.UserRepository;
 	"TRUNCATE TABLE concert_seats",
 	"TRUNCATE TABLE concert_dates",
 	"TRUNCATE TABLE concerts",
+	"TRUNCATE TABLE user_point_histories",
+	"TRUNCATE TABLE user_points",
 	"TRUNCATE TABLE users",
 	"SET FOREIGN_KEY_CHECKS=1"
 }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)

--- a/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import static io.hhplus.concert.interfaces.api.token.TokenErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -300,8 +301,11 @@ public class TokenServiceIntegrationTest {
 			TokenCommand.IssueWaitingToken.from(sampleUser)
 		);
 		Token token = tokenInfo.token();
-		log.info("만료여부를 확인하기 위해 6분 대기");
-		Thread.sleep(6 * 60 * 1000);
+		log.info("토큰 만료");
+		token.expire(LocalDateTime.now().minusSeconds(1));
+		tokenRepository.saveOrUpdate(token);
+
+
 		// when & then
 		BusinessException exception = assertThrows(
 			BusinessException.class,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,8 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format-sql: true


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

**1. 테스트컨테이너의 JPA 관련설정은 application-test.yml 을 사용하도록 수정**
- 테스트컨테이너의 설정을 application-test.yml에서 관리하도록 수정 : 58e6c5f 

**2. 빠른 테스트를 위하여 토큰/임시예약상태 만료를 재현하는 Thread.sleep() 코드 제거 및 테스트 실행속도 개선**
 - 임시예약 만료상태로 변경하는 인스턴스함수 추가: 8363c9f
 - 임시예약 만료상태로 변경시, 현재날짜기준으로 과거날짜가 아니면 예외를 전달하도록 커스텀 예외메시지 추가: 9d17c10
 - 임시예약상태로 변경하는 인스턴스함수 추가로 테스트코드 수정 및 &Thread.sleep() 코드 제거: a29034d


**3. 로그 인터셉터 추가**
- 로그 인터셉터 추가 및 적용: b66b9407

**4. 토큰유즈케이스 통합테스트케이스작성**
- 토큰유즈케이스 통합테스트 작성 및 서비스/유즈케이스 내부로직수정: 43b0b16

**5. 토큰 스케줄러 추가**
- 폴링기반의 상위100개 대기열토큰 토큰활성화 스케줄러 추가: 5d3403b

**6. 동일한 사용자가 여러개의 예약을 결제할때 동시성테스트 케이스 만들기**
- 동일한 사용자가 여러개의 예약을 결제 및 예약확정처리 할때 동시성테스트케이스 만들기: b01da7b
여기서 동시에 접근해야되는 공유자원은 사용자의 포인트이므로 비관적락을 사용합니다. (저의경우에는 포인트충전/사용 동시요청시 데이터정합성을 깨지지않게하기위해서 비관적락을 사용햇고 자세한 내용은 하단 링크에서 볼 수 있습니다) 여러개의 예약들을 동시에 결제요청하기때문입니다.
  - [RDBMS 락을활용한 동시성제어보고서](https://github.com/loveAlakazam/hh-08-concert/wiki/07_RDBMS_%EB%9D%BD%EC%9D%84%ED%99%9C%EC%9A%A9%ED%95%9C_%EB%8F%99%EC%8B%9C%EC%84%B1%EC%A0%9C%EC%96%B4%EB%B3%B4%EA%B3%A0%EC%84%9C)

---

> 피드백 보완하기
- [x] 테스트코드는 빨라야한다. 만료시간을 직접재현하지말고 application.properties에서 프로퍼티를 관리하고 주입받아서 구현하는 방식을 활용하자.
   - Thread.sleep 으로인한 길어진 테스트 실행시간을 단축시키자 : (as-is) `5분~6분 `-> (to-be) `1초`
   - 상태별로 객체를 지역변수로 쓰는 방향
   - application.properties를 활용하여 테스트환경과 운영환경에 따라서 토큰만료값을 다르게 나타내기?
- [x] JPA관점에서 application.yml을 별도로 구성하도록 변경하자.
- [x] (동시성테스트 digging) 동일한 사용자가 여러개의 예약을 결제할때 동시성테스트만들기
- [x] 로깅추가


---

## 빠른 테스트실행을 위해서 엔티티에 상태변경 코드작성 및 테스트코드 수정

### 문제점

콘서트에서는 임시예약상태는 5분간 예약상태로 뒀습니다.
5분내로 결제하면 좌석예약이 확정됩니다. 반대로 5분내로 결제하지 못하고 5분이 지나버리면 임시예약상태가 만료됩니다. 

저는 Thread.sleep() 으로 만료상태를 테스트코드에 재현했습니다. 테스트코드를 실행하는데 given에 임시예약 만료상태의 예약이 들어있는 테스트코드1개는 약 5~6분을 기다려야됩니다. 대기해야되는 테스트코드들이 계속 생기게되면 테스트를 실행하는 시간이 점점 늘어날겁니다.
만일 유효시간이 5분이아닌 30분이라면 30분을 대기해야되는 불상사가 일어날겁니다.

실제로 제가 그동안 작성한 테스트개수가 158개인데 158개를 완료할때까지 실행하는 시간은 51분정도 됐습니다.
이게 맞는지 4월 26일(토) 오프라인 미팅에서 우연히 바로 옆자리의 렌코치님께 물어봤습니다. 렌코치님께서는 테스트는 실행속도가 빨라야한다고 말씀해주셨습니다.

<br><br>

---

### 어떻게 해결했나요?

아하포인트를 듣는데서 멈추지않고 바로 행동으로 옮겼습니다, 레디스과제를 잠시 대기시키고 테스트실행속도를 빠르게하려면 어떻게 리팩터링을할까에 대해 고민해봤습니다. 고민을 해보던중 엔티티의 인스턴스함수로  상태변경하는 코드를 작성했습니다.

> 토큰만료상태를 나타내는 인스턴스 함수

```java
@Entity
@Getter
@Table(name = "tokens")
@RequiredArgsConstructor
public class Token extends BaseEntity {
    ...
    public void expire(LocalDateTime expiredAt) {
        if(isPastDateTime(expiredAt))
            this.expiredAt =  expiredAt;
    }
}
```

>  임시예약만료상태를 나타내는 인스턴스 함수

```java
@Entity
@Getter
@Table(name = "reservations")
@RequiredArgsConstructor
public class Reservation extends BaseEntity {
        ...

	/**
	 * 만료일자를 지정하여, 예약의 상태를 임시예약만료 상태로 변경해주는 인스턴스함수
	 */
	public void expireTemporaryReserve(LocalDateTime expiredAt) {
		if(!DateValidator.isPastDateTime(expiredAt))
			throw new InvalidValidationException(EXPIRED_DATE_SHOULD_BE_PAST_DATETIME);
		this.tempReservationExpiredAt = expiredAt;

	}
}
```


**AS-IS**

> 테스트코드1. (엔티티 단위테스트) ReservationEntityTest.java

```java
	@Test
	void 임시예약_만료일자가_이미_지나간경우_임시예약상태에서_취소상태로_변경한다() throws InterruptedException {
		// given
		User user = User.of("테스트"); // 유저 초기화
		// 콘서트, 콘서트일정, 콘서트 좌석 초기화
		Concert concert = Concert.create(
			"테스트 콘서트",
			"테스트 아티스트",
			LocalDate.now(),
			"테스트 콘서트 장소",
			15000
		);
		// 예약하려는 콘서트 - concert
		// 예약하려는 콘서트일정 - concertDate
		// 예약하려는 콘서트좌석 - concertSeat
		ConcertDate concertDate = concert.getDates().get(0);
		ConcertSeat concertSeat = concertDate.getSeats().get(0);
		Reservation reservation = assertDoesNotThrow(() -> Reservation.of(user, concert, concertDate, concertSeat));

		// 좌석 임시예약
		log.info("임시예약 상태로 변경");
		assertDoesNotThrow(() -> reservation.temporaryReserve());

		// 임시예약상태로 6분간 sleep 한다
		log.info("6분간 sleep 상태로 대기");
		Thread.sleep(6 * 60 * 1000);  // 👎  스레드를 슬립시켜서 6분간 대기하도록함

		// when
		// 예약취소
		log.info("예약 취소 상태로 변경");
		reservation.cancel();

                 // then
		assertEquals(true, concertSeat.isAvailable()); // 좌석 예약 가능
		assertEquals(CANCELED, reservation.getStatus()); // 취소 상태 - CANCELED
		assertTrue(DateValidator.isPastDateTime(reservation.getTempReservationExpiredAt())); // 이미 만료일자가 과거인지 확인
	}
```

<br>

- 실행결과: 실행하는데 6분 소요

<img width="738" alt="Image" src="https://github.com/user-attachments/assets/cbf07286-a473-41d5-bbf3-2d89454dd8be" />

<br><br>

> 테스크코드2. (예약 통합테스트) ReservationServiceIntegrationTest.java

```java
public class ReservationServiceIntegrationTest {
	@Order(9)
	@Test
	void 예약확정요청중_예약상태가_임시예약상태가_아닌_만료된_상태라면_BusinessException_예외발생() throws InterruptedException {
		// given
		// 임시예약이 만료된 상태의 예약이다.
		log.info("임시예약 신청하여 좌석 5분간 임시점유 상태");
		ReservationInfo.TemporaryReserve info = reservationService.temporaryReserve(
			ReservationCommand.TemporaryReserve.of(sampleUser, sampleConcertSeat)
		);
		Reservation reservation = info.reservation();
		long reservationId = reservation.getId();

		log.info("5분 + 1ms 대기시켜서 임시예약만료 상태를 재현");
		Thread.sleep(TEMPORARY_RESERVATION_DURATION_MILLISECOND + 1); // 👎  5분 1ms 를  슬립시킴

		log.info("임시예약이 만료됨");
		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt())); // 임시예약만료됐는지 확인

		// when & then
		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
		BusinessException exception = assertThrows(
			BusinessException.class,
			() -> reservationService.confirm(ReservationCommand.Confirm.of(reservationId))
		);
		assertEquals(INVALID_ACCESS.getMessage(), exception.getMessage());
	}

	/**
	 * 예약 취소
	 */
	@Order(10)
	@Test
	void 예약상태가_임시예약상태가_아닌_만료된_상태라면_예약상태는_취소상태로_변경이_가능하다() throws InterruptedException {
		// given
		// 임시예약이 만료된 상태의 예약이다.
		log.info("임시예약 신청하여 좌석 5분간 임시점유 상태");
		ReservationInfo.TemporaryReserve info = reservationService.temporaryReserve(
			ReservationCommand.TemporaryReserve.of(sampleUser, sampleConcertSeat)
		);
		Reservation reservation = info.reservation();
		assertNotNull(reservation);
		assertTrue(reservation.isTemporary()); // 임시예약상태
		long reservationId = reservation.getId();
		log.info("5분 + 1ms 대기하여 임시예약만료상태를 재현");
		Thread.sleep(TEMPORARY_RESERVATION_DURATION_MILLISECOND + 1); // 👎 5분 1ms를 스레드 슬립시킴

		log.info("임시예약이 만료됨");
		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt())); // 임시예약이 만료됐는지확인

		// when & then
		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
		ReservationInfo.Cancel cancelInfo = assertDoesNotThrow(
			() -> reservationService.cancel(ReservationCommand.Cancel.of(reservationId))
		);
		assertNotNull(cancelInfo.reservation());
		assertInstanceOf(Reservation.class, cancelInfo.reservation());
		// 예약상태 확인
		reservation = cancelInfo.reservation();
		assertEquals(CANCELED, reservation.getStatus());
		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()));
		assertNotNull(reservation.getTempReservationExpiredAt());
		assertNull(reservation.getReservedAt());
		// 예약만료로 점유된 좌석도 임시예약이 취소되어 예약가능한 상태로 변경
		assertTrue(reservation.getConcertSeat().isAvailable());
	}
}
```

<br>

- 실행결과

<img width="1243" alt="Image" src="https://github.com/user-attachments/assets/7621b0e9-1cc1-4e14-b837-3f343fa93ba6" />


<br><br>

**TO-BE**

> 테스트코드1. (엔티티 단위테스트) ReservationEntityTest.java

```java
public class ReservationEntityTest {

	@Test
	void 임시예약_만료일자가_이미_지나간경우_임시예약상태에서_취소상태로_변경한다() throws InterruptedException {
		// given
		User user = User.of("테스트"); // 유저 초기화
		// 콘서트, 콘서트일정, 콘서트 좌석 초기화
		Concert concert = Concert.create(
			"테스트 콘서트",
			"테스트 아티스트",
			LocalDate.now(),
			"테스트 콘서트 장소",
			15000
		);
		// 예약하려는 콘서트 - concert
		// 예약하려는 콘서트일정 - concertDate
		// 예약하려는 콘서트좌석 - concertSeat
		ConcertDate concertDate = concert.getDates().get(0);
		ConcertSeat concertSeat = concertDate.getSeats().get(0);

		Reservation reservation = assertDoesNotThrow(() -> Reservation.of(user, concert, concertDate, concertSeat));

		// 좌석 임시예약
		log.info("임시예약 상태로 변경");
		assertDoesNotThrow(() -> reservation.temporaryReserve());

		// 임시예약 기간이 만료된다
		log.info("임시예약일자 만료");
		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1)); // ✍ 임시예약만료상태 변경 적용

		// when
		log.info("예약 취소 상태로 변경");
		reservation.cancel();

                 // then
		assertEquals(true, concertSeat.isAvailable()); // 좌석 예약 가능
		assertEquals(CANCELED, reservation.getStatus()); // 취소 상태 - CANCELED
		assertTrue(DateValidator.isPastDateTime(reservation.getTempReservationExpiredAt())); // 이미 만료일자가 과거인지 확인
	}
}
```

<br>

- 테스트 실행결과 - 실행시간: 14ms

<img width="620" alt="Image" src="https://github.com/user-attachments/assets/8d6f0f71-78ee-42e8-81c4-31dba0743d71" />

<br><br>

> 테스트코드2. (예약 통합테스트) ReservationServiceIntegrationTest.java

```java
public class ReservationServiceIntegrationTest {
	@Order(9)
	@Test
	void 예약확정요청중_예약상태가_임시예약상태가_아닌_만료된_상태라면_BusinessException_예외발생() throws InterruptedException {
		// given
		// 임시예약이 만료된 상태의 예약이다.
		log.info("임시예약 신청하여 좌석 5분간 임시점유 상태");
		ReservationInfo.TemporaryReserve info = reservationService.temporaryReserve(
			ReservationCommand.TemporaryReserve.of(sampleUser, sampleConcertSeat)
		);
		Reservation reservation = info.reservation();
		long reservationId = reservation.getId();

		log.info("임시예약이 만료됨");
		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1)); // 👈  임시예약만료상태 변경 적용
		reservationRepository.saveOrUpdate(reservation); // 👈  영속성 컨텍스트를 데이터베이스에 반영

		// when & then
		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
		BusinessException exception = assertThrows(
			BusinessException.class,
			() -> reservationService.confirm(ReservationCommand.Confirm.of(reservationId))
		);
		assertEquals(INVALID_ACCESS.getMessage(), exception.getMessage());
	}

	/**
	 * 예약 취소
	 */
	@Order(10)
	@Test
	void 예약상태가_임시예약상태가_아닌_만료된_상태라면_예약상태는_취소상태로_변경이_가능하다() throws InterruptedException {
		// given
		// 임시예약이 만료된 상태의 예약이다.
		log.info("임시예약 신청하여 좌석 5분간 임시점유 상태");
		ReservationInfo.TemporaryReserve info = reservationService.temporaryReserve(
			ReservationCommand.TemporaryReserve.of(sampleUser, sampleConcertSeat)
		);
		Reservation reservation = info.reservation();
		long reservationId = reservation.getId();
                
		log.info("임시예약이 만료됨");
		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1)); // 👈 임시예약만료상태 변경 적용
		reservationRepository.saveOrUpdate(reservation); // 👈  영속성 컨텍스트를 데이터베이스에 반영

		// when & then
		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
		ReservationInfo.Cancel cancelInfo = assertDoesNotThrow(
			() -> reservationService.cancel(ReservationCommand.Cancel.of(reservationId))
		);

		// 예약상태 확인
		reservation = cancelInfo.reservation();
		assertEquals(CANCELED, reservation.getStatus());
		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()));
		assertNotNull(reservation.getTempReservationExpiredAt());
		assertNull(reservation.getReservedAt());

		// 예약만료로 점유된 좌석도 임시예약이 취소되어 예약가능한 상태로 변경
		assertTrue(reservation.getConcertSeat().isAvailable());
	}
}
```

<br>

- 테스트 실행결과

<img width="1029" alt="Image" src="https://github.com/user-attachments/assets/22e69556-20c8-459b-9f68-5c3e42f376ee" />

<br><br>

> 리팩토링후 158개 테스트케이스 전체 실행결과

<img width="739" alt="Image" src="https://github.com/user-attachments/assets/c125f9ef-ac10-45a0-b11f-93bfa6328be1" />


### 리팩터링 후의 느낀점 및 회고

이미 작성된 테스트코드를 다시 수정하는데 시간이 소요됐습니다. 과거의 제가 작성한 코드라지만 다시 읽고 적응하는데 힘이 들었습니다. 이런것이 유지보수가 기능을 만드는것보다 더 신경써야될게 많다는걸 제가 과거의 코드를 고치는것을 통해 알게됐습니다.

만일 테스트의 실행속도가 느리다면 유지보수도 쉽지 않고, 내가 테스트를 실행하는 사이에 잠재되어있는 사이드이펙트들도 놓칠수있다는걸 알게됐습니다. 왜냐면, 전체를 테스트하지 않는다면 토큰인터셉터 테스트에서 사이드이펙트가 일어난것도 모른채 방치했을겁니다. 


51분 소요되는 테스트실행시간을 8초 761ms 로 대폭 단축을 했습니다.
그리고 빠른 테스트 덕분에 유지보수가 Pending 상태가 되지 않고 계속 리팩터링해나갈수있다는것이 좋았습니다.

---

<br>

##  JPA 관점에서 application.yml을 별도로 구성하도록 변경하기

- Spring ver 3.4.4

### [AS-IS]
```java
@TestConfiguration
public class TestcontainersConfiguration {

	@Container
	public static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
		.withDatabaseName("hhplus")
			.withUsername("test")
			.withPassword("test");

	static  {
		MYSQL_CONTAINER.start();

		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
		System.setProperty("spring.jpa.hibernate.ddl-auto", "create");
		System.setProperty("spring.jpa.show-sql", "true");
		System.setProperty("spring.jpa.properties.hibernate.format-sql", "true");
	}
        @PreDestroy
	public void preDestroy() {
		if ( MYSQL_CONTAINER.isRunning() ) {
			MYSQL_CONTAINER.stop();
		}
	}
}
```

### [TO-BE]

> TestcontainersConfiguration.java

```java
@TestConfiguration
public class TestcontainersConfiguration {
	private static final String DATABASE_NAME="hhplus";
	private static final String USERNAME="test";
	private static final String PASSWORD="test";

	@Container
	public static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
		.withDatabaseName(DATABASE_NAME)
			.withUsername(USERNAME)
			.withPassword(PASSWORD)
		;

	static  {
		MYSQL_CONTAINER.start(); // 컨테이너를 static 블록에서 시작
	}

	@DynamicPropertySource
	static void registerMySQLProperties(DynamicPropertyRegistry registry) {
                // 가변적인 설정값들을 저장
		registry.add("spring.datasource.url", () -> MYSQL_CONTAINER.getJdbcUrl()+"?characterEncoding=UTF-8&serverTimezone=UTC");
		registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
		registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
	}
}

```

> application-test.yml

- 가변적인 값이 아닌 System.setProperty에서 고정값인 설정값들은 모두 application-test.yml 에서 관리하도록 수정했습니다.

```yml
spring:
  jpa:
    hibernate:
      ddl-auto: create
    show-sql: true
    properties:
      hibernate:
        format-sql: true
```


테스트컨테이너의 `MYSQL_CONTAINER.getJdbcUrl()`의 주소를 살펴보면... 호스트정보와 포트번호가 동적임을 알 수 있습니다
특히 로컬호스트로 사용할경우에는 getHost()값이 localhost값을 기본값으로 지정하지만 포트번호는 **랜덤** 입니다. 
그러므로 가변적인 값을 가진경우 테스트컨테이너 설정값을 셋팅하려면 `@DynamicPropertySource` 를 이용해서 정의해야합니다.

```java
// MySQLContainer.java

public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
...
    @Override
    public String getJdbcUrl() {
        String additionalUrlParams = constructUrlParameters("?", "&");
        return "jdbc:mysql://" + getHost() + ":" + getMappedPort(MYSQL_PORT) + "/" + databaseName + additionalUrlParams;
    }
}
```

고친후에 테스트를 실행해봤더니...테스트는 통과됐지만  FileNotFoundException이 발생했습니다. 

```shell
Capture agent: unable to read settings
java.io.FileNotFoundException: /var/folders/_2/8cf8mgd16q9cm_44q_r667000000gp/T/capture14141612850555708231.props (No such file or directory)
    at java.base/java.io.FileInputStream.open0(Native Method)
    at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
    at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
    at com.intellij.rt.debugger.agent.DebuggerAgent.readAndApplyProperties(DebuggerAgent.java:46)
    at com.intellij.rt.debugger.agent.DebuggerAgent.premain(DebuggerAgent.java:26)
```

이는 테스트컨테이너와는 별개로
intelij IDEA의 디버깅에이전트의 관련된문제라서 "캐시무효화" 시키고 다시 빌드를 했더니 아무런 문제가 없었습니다! 흐뭇~ :D

<img width="1309" alt="Image" src="https://github.com/user-attachments/assets/d5212a2b-4dd3-420e-a7ca-9b01d07a1a38" />


---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1: 테스트코드가 너무 지져분하지 않은지 피드백이 필요할거같습니다!

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
