### PR TITLE
[Step11~12] 대용량 트래픽 & 데이터 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	// Swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -51,6 +54,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
+	testImplementation 'org.testcontainers:redis'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// DateFormatted DataType Serialization
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 	// Swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
-	testImplementation 'org.testcontainers:redis'
+	testImplementation 'com.redis:testcontainers-redis:2.2.2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
+  redis:
+    image: redis
+    container_name: redis-local
+    ports:
+      - "6379:6379"
 
 networks:
   default:

--- a/src/main/java/io/hhplus/concert/ConcertApplication.java
+++ b/src/main/java/io/hhplus/concert/ConcertApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-// @EnableScheduling
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = "io.hhplus.concert.infrastructure.persistence")
 @EntityScan(basePackages = "io.hhplus.concert.domain")

--- a/src/main/java/io/hhplus/concert/application/usecase/payment/PaymentUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/payment/PaymentUsecase.java
@@ -57,7 +57,7 @@ public class PaymentUsecase {
 		// 임시예약상태일 경우에 결제 가능
 		if(reservation.isTemporary()) {
 			// 포인트 사용
-			userPoint.use(concertSeatPrice);
+			userService.usePoint(UserPointCommand.UsePoint.of(criteria.userId(), concertSeatPrice));
 
 			// 예약 확정 변경
 			reservation.confirm();

--- a/src/main/java/io/hhplus/concert/application/usecase/token/TokenCriteria.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/token/TokenCriteria.java
@@ -2,6 +2,8 @@ package io.hhplus.concert.application.usecase.token;
 
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 
+import java.util.UUID;
+
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
 import io.hhplus.concert.interfaces.api.token.TokenRequest;
 
@@ -12,10 +14,10 @@ public record TokenCriteria(){
 			return new IssueWaitingToken(userId);
 		}
 	}
-	public record GetWaitingTokenPositionAndActivateWaitingToken(long userId) {
-		public static GetWaitingTokenPositionAndActivateWaitingToken of(long userId) {
-			if(userId <= 0) throw new InvalidValidationException(ID_SHOULD_BE_POSITIVE_NUMBER);
-			return new GetWaitingTokenPositionAndActivateWaitingToken(userId);
+	public record GetWaitingTokenPositionAndActivateWaitingToken(UUID uuid) {
+		public static GetWaitingTokenPositionAndActivateWaitingToken of(UUID uuid) {
+			if(uuid == null) throw new InvalidValidationException(NOT_NULLABLE);
+			return new GetWaitingTokenPositionAndActivateWaitingToken(uuid);
 		}
 	}
 }

--- a/src/main/java/io/hhplus/concert/application/usecase/token/TokenUsecase.java
+++ b/src/main/java/io/hhplus/concert/application/usecase/token/TokenUsecase.java
@@ -22,6 +22,12 @@ public class TokenUsecase {
 	private final UserService userService;
 	private final TokenService tokenService;
 
+	/**
+	 * 사용자가 대기상태의 토큰발급 요청을 한다.
+	 *
+	 * @param criteria
+	 * @return TokenResult.IssueWaitingToken
+	 */
 	public TokenResult.IssueWaitingToken issueWaitingToken(TokenCriteria.IssueWaitingToken criteria) {
 		// 유저정보 조회
 		User user = userService.getUser(UserCommand.Get.of(criteria.userId()));
@@ -29,11 +35,21 @@ public class TokenUsecase {
 		TokenInfo.IssueWaitingToken info = tokenService.issueWaitingToken(TokenCommand.IssueWaitingToken.from(user));
 		return TokenResult.IssueWaitingToken.of(info, user);
 	}
+
+	/**
+	 * 대기번호 조회 요청 및 토큰활성화 로직
+	 * - 스케줄러를 통해서 폴링방식 구현.
+	 * - 대기번호가 1번인경우에는 토큰활성화 진행.
+	 * - 대기번호가 1이아니라면 대기번호상태를 나타냄.
+	 *
+	 * @param criteria
+	 * @return TokenResult.GetWaitingTokenPositionAndActivateWaitingToken
+	 */
 	public TokenResult.GetWaitingTokenPositionAndActivateWaitingToken getWaitingTokenPositionAndActivateWaitingToken(
 		TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken criteria)
 	{
-		// 토큰정보 조회
-		TokenInfo.GetTokenByUserId info = tokenService.getTokenByUserId(TokenCommand.GetTokenByUserId.of(criteria.userId()));
+		// UUID로 토큰정보 조회
+		TokenInfo.GetTokenByUUID info = tokenService.getTokenByUUID(TokenCommand.GetTokenByUUID.of(criteria.uuid()));
 		Token token = info.token();
 		if(token == null) throw new BusinessException(TOKEN_NOT_FOUND);
 
@@ -41,8 +57,11 @@ public class TokenUsecase {
 		int position = tokenService.getCurrentPosition(token.getUuid());
 
 		// 토큰의 대기상태번호가 1번이라면(대기열의 맨앞에 있으므로) 대기토큰을 활성화를 시킨다
-		if(position == 1)
-			tokenService.activateToken(TokenCommand.ActivateToken.of(token.getUuid()));
+		if(position == 1) {
+			TokenInfo.ActivateToken activateTokenInfo = tokenService.activateToken(TokenCommand.ActivateToken.of(token.getUuid()));
+			token = activateTokenInfo.token();
+			position = -1; // 이미 dequeue를 했으므로 -1로 변경한다.
+		}
 
 		return TokenResult.GetWaitingTokenPositionAndActivateWaitingToken.of(
 			token.getStatus(),

--- a/src/main/java/io/hhplus/concert/config/JpaConfig.java
+++ b/src/main/java/io/hhplus/concert/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.config.jpa;
+package io.hhplus.concert.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/io/hhplus/concert/config/RedisConfig.java
+++ b/src/main/java/io/hhplus/concert/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package io.hhplus.concert.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Redis 설정 및 직렬화
+ */
+@Configuration
+public class RedisConfig {
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(factory);
+
+		template.setKeySerializer(new StringRedisSerializer());
+
+		// ObjectMapper with JavaTimeModule
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 로 출력
+
+		// Redis value serializer
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+		return template;
+	}
+}

--- a/src/main/java/io/hhplus/concert/domain/common/BaseEntity.java
+++ b/src/main/java/io/hhplus/concert/domain/common/BaseEntity.java
@@ -4,6 +4,7 @@ package io.hhplus.concert.domain.common;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -16,7 +17,8 @@ import lombok.Getter;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
-	@Column(name="created_at")
+	@CreatedDate
+	@Column(name="created_at", updatable = false)
 	protected LocalDateTime createdAt;
 
 	@LastModifiedDate

--- a/src/main/java/io/hhplus/concert/domain/concert/Concert.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/Concert.java
@@ -9,6 +9,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import io.hhplus.concert.domain.common.BaseEntity;
 import io.hhplus.concert.domain.reservation.Reservation;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
@@ -68,12 +71,17 @@ public class Concert extends BaseEntity {
 	 */
 	// 콘서트:콘서트날짜 = 1:N
 	@OneToMany(mappedBy = "concert", cascade = CascadeType.ALL, orphanRemoval = true )
+	@JsonIgnore
 	private List<ConcertDate> dates = new ArrayList<>();
+
 	// 콘서트:콘서트좌석 = 1:N
 	@OneToMany(mappedBy = "concert", cascade = CascadeType.ALL, orphanRemoval = true )
+	@JsonIgnore
 	private List<ConcertSeat> seats = new ArrayList<>();
+
 	// 콘서트:예약 = 1:N
 	@OneToMany(mappedBy = "concert")
+	@JsonIgnore
 	private List<Reservation> reservations = new ArrayList<>();
 
 	/**

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertDate.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertDate.java
@@ -85,11 +85,11 @@ public class ConcertDate extends BaseEntity {
 	// 콘서트날짜:콘서트=N:1
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name ="concert_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
-	@JsonBackReference
+	@JsonBackReference("concert-dates")
 	private Concert concert;
 	// 콘서트날짜:좌석=1:N
 	@OneToMany(mappedBy = "concertDate", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonManagedReference
+	@JsonManagedReference("concertDate-seats")
 	private List<ConcertSeat> seats = new ArrayList<>();
 	// 콘서트날짜:예약=1:N
 	@OneToMany(mappedBy = "concertDate")

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertDate.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertDate.java
@@ -8,6 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import io.hhplus.concert.domain.common.BaseEntity;
 import io.hhplus.concert.domain.reservation.Reservation;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
@@ -81,12 +85,15 @@ public class ConcertDate extends BaseEntity {
 	// 콘서트날짜:콘서트=N:1
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name ="concert_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+	@JsonBackReference
 	private Concert concert;
 	// 콘서트날짜:좌석=1:N
 	@OneToMany(mappedBy = "concertDate", cascade = CascadeType.ALL, orphanRemoval = true)
+	@JsonManagedReference
 	private List<ConcertSeat> seats = new ArrayList<>();
 	// 콘서트날짜:예약=1:N
 	@OneToMany(mappedBy = "concertDate")
+	@JsonIgnore
 	private List<Reservation> reservations = new ArrayList<>();
 
 	/**

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertDateRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertDateRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 import io.hhplus.concert.domain.concert.ConcertDate;
 
 public interface ConcertDateRepository {
-	List<ConcertDate> findAllAvailable(long concertId);
+	ConcertInfo.GetConcertDateList findAllAvailable(long concertId);
 	ConcertDate findConcertDateById(long id);
 
 	List<Long> findFinishedConcertDateIds();

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertInfo.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertInfo.java
@@ -56,18 +56,44 @@ public class ConcertInfo {
 			);
 		}
 	}
+	/* 콘서트 좌석 목록조회 - GetConcertSeatList */
+	public record GetConcertSeatList(List<ConcertSeatListDto> concertSeatList) {
+		public static GetConcertSeatList from(List<ConcertSeat> concertSeats) {
+			List<ConcertSeatListDto> concertSeatListDtos = concertSeats.stream().map(ConcertSeatListDto::from).toList();
+			return new GetConcertSeatList(concertSeatListDtos);
 		}
 	}
-	public record GetConcertSeatList(List<ConcertSeat> concertSeatList) {
-		public static GetConcertSeatList from(List<ConcertSeat> concertSeatList) {
-			return new GetConcertSeatList(concertSeatList);
+	public record ConcertSeatListDto(
+		long id,
+		int number,
+		long price,
+		boolean isAvailable,
+		long concertId,
+		long concertDateId,
+		long version
+	) {
+		public static ConcertSeatListDto from(ConcertSeat concertSeat) {
+			if(concertSeat.getConcert() == null || concertSeat.getConcertDate() == null)
+				throw new BusinessException(NOT_NULLABLE);
+
+			return new ConcertSeatListDto(
+				concertSeat.getId(),
+				concertSeat.getNumber(),
+				concertSeat.getPrice(),
+				concertSeat.isAvailable(),
+				concertSeat.getConcert().getId(),
+				concertSeat.getConcertDate().getId(),
+				concertSeat.getVersion()
+			);
 		}
 	}
+	/* 콘서트 좌석 단건 조회 - GetConcertSeat */
 	public record GetConcertSeat(ConcertSeat concertSeat) {
 		public static GetConcertSeat from(ConcertSeat concert) {
 			return new GetConcertSeat(concert);
 		}
 	}
+	/* 콘서트 생성 - CreateConcert */
 	public record CreateConcert(Concert concert) {
 		public static CreateConcert from(Concert concert) {
 			return new CreateConcert(concert);

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertInfo.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertInfo.java
@@ -1,13 +1,26 @@
 package io.hhplus.concert.domain.concert;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
 
 public class ConcertInfo {
-	public record GetConcertList(List<Concert> concerts, int size) {
+	public record GetConcertListDto(long id, String name, String artistName, LocalDateTime createdAt, boolean deleted) {
+		public static GetConcertListDto from(Concert concert) {
+			return new GetConcertListDto(
+				concert.getId(),
+				concert.getName(),
+				concert.getArtistName(),
+				concert.getCreatedAt(),
+				concert.isDeleted()
+			);
+		}
+	}
+	public record GetConcertList(List<GetConcertListDto> concerts, int size) {
 		public static GetConcertList from(List<Concert> concerts) {
-			return new GetConcertList(concerts, concerts.size());
+			List<GetConcertListDto> concertListDtos = concerts.stream().map(GetConcertListDto::from).toList();
+			return new GetConcertList(concertListDtos, concertListDtos.size());
 		}
 	}
 	public record GetConcertDateList(List<ConcertDate> concertDates, int size) {

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertInfo.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertInfo.java
@@ -1,11 +1,23 @@
 package io.hhplus.concert.domain.concert;
 
+import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
 
+import io.hhplus.concert.interfaces.api.common.BusinessException;
+
 public class ConcertInfo {
+	/* 콘서트목록조회 - GetConcertList */
+	public record GetConcertList(List<GetConcertListDto> concerts, int size) {
+		public static GetConcertList from(List<Concert> concerts) {
+			List<GetConcertListDto> concertListDtos = concerts.stream().map(GetConcertListDto::from).toList();
+			return new GetConcertList(concertListDtos, concertListDtos.size());
+		}
+	}
 	public record GetConcertListDto(long id, String name, String artistName, LocalDateTime createdAt, boolean deleted) {
 		public static GetConcertListDto from(Concert concert) {
 			return new GetConcertListDto(
@@ -17,15 +29,33 @@ public class ConcertInfo {
 			);
 		}
 	}
-	public record GetConcertList(List<GetConcertListDto> concerts, int size) {
-		public static GetConcertList from(List<Concert> concerts) {
-			List<GetConcertListDto> concertListDtos = concerts.stream().map(GetConcertListDto::from).toList();
-			return new GetConcertList(concertListDtos, concertListDtos.size());
+	/* 콘서트 일정 목록조회 - GetConcertDateList */
+	public record GetConcertDateList(List<GetConcertDateListDto> concertDates, int size) {
+		public static GetConcertDateList from(List<ConcertDate> concertDates) {
+			List<GetConcertDateListDto> concertDateListDtos = concertDates.stream().map(GetConcertDateListDto::from).toList();
+			return new GetConcertDateList(concertDateListDtos, concertDateListDtos.size());
 		}
 	}
-	public record GetConcertDateList(List<ConcertDate> concertDates, int size) {
-		public static GetConcertDateList from(List<ConcertDate> concertDates) {
-			return new GetConcertDateList(concertDates, concertDates.size());
+	public record GetConcertDateListDto(
+		long id,
+		LocalDate progressDate,
+		String place,
+		long concertId,
+		List<ConcertSeatListDto> concertSeats
+	) {
+		public static GetConcertDateListDto from(ConcertDate concertDate) {
+			if(concertDate.getSeats() == null || concertDate.getConcert() == null)
+				throw new BusinessException(NOT_NULLABLE);
+
+			return new GetConcertDateListDto(
+				concertDate.getId(),
+				concertDate.getProgressDate(),
+				concertDate.getPlace(),
+				concertDate.getConcert().getId(),
+				concertDate.getSeats().stream().map(ConcertSeatListDto::from).toList()
+			);
+		}
+	}
 		}
 	}
 	public record GetConcertSeatList(List<ConcertSeat> concertSeatList) {

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 import io.hhplus.concert.domain.concert.Concert;
 
 public interface ConcertRepository {
-	List<Concert> findAll();
+	ConcertInfo.GetConcertList findAll();
 	Concert findById(long id);
 	Concert saveOrUpdate(Concert concert);
 

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
@@ -3,6 +3,9 @@ package io.hhplus.concert.domain.concert;
 import static io.hhplus.concert.interfaces.api.concert.ConcertErrorCode.*;
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.hhplus.concert.domain.common.BaseEntity;
 import io.hhplus.concert.domain.reservation.Reservation;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
@@ -52,14 +55,19 @@ public class ConcertSeat extends BaseEntity {
 	// 콘서트좌석:콘서트=N:1
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "concert_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+	@JsonBackReference
 	private Concert concert;
+
 	// 콘서트좌석:콘서트날짜=N:1
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name= "concert_date_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+	@JsonBackReference
 	private ConcertDate concertDate;
+
 	// 콘서트좌석:예약=1:1
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "reservation_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+	@JsonIgnore
 	private Reservation reservation;
 
 	/**

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
@@ -55,13 +55,13 @@ public class ConcertSeat extends BaseEntity {
 	// 콘서트좌석:콘서트=N:1
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "concert_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
-	@JsonBackReference
+	@JsonBackReference("concert-seats")
 	private Concert concert;
 
 	// 콘서트좌석:콘서트날짜=N:1
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name= "concert_date_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
-	@JsonBackReference
+	@JsonBackReference("concertDate-seats")
 	private ConcertDate concertDate;
 
 	// 콘서트좌석:예약=1:1

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertSeat.java
@@ -43,7 +43,7 @@ public class ConcertSeat extends BaseEntity {
 	private boolean isAvailable = true; // 예약가능여부
 
 	@Version
-	private int version; // 낙관적락
+	private long version; // 낙관적락
 
 
 	/**
@@ -72,6 +72,7 @@ public class ConcertSeat extends BaseEntity {
 		this.number = number;
 		this.price = price;
 		this.isAvailable = isAvailable;
+		this.version = 0L;
 	}
 	public static ConcertSeat of (Concert concert, ConcertDate concertDate, int number, long price, boolean isAvailable) {
 		if(concert == null) throw new BusinessException(NOT_NULLABLE);

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertSeatRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertSeatRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 
 public interface ConcertSeatRepository {
-	List<ConcertSeat> findConcertSeats(long concertId, long concertDateId);
+	ConcertInfo.GetConcertSeatList findConcertSeats(long concertId, long concertDateId);
 	ConcertSeat getConcertSeatInfo(long id);
 	Optional<ConcertSeat> findById(long id);
 	ConcertSeat saveOrUpdate(ConcertSeat concertSeat);

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertService.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertService.java
@@ -33,7 +33,7 @@ public class ConcertService {
     private static final Duration CONCERT_DATE_LIST_CACHE_TTL = Duration.ofMinutes(30);
 
     public static final String CONCERT_SEAT_LIST_CACHE_KEY= "concert_seat:list";
-    private static final Duration CONCERT_SEAT_LIST_CACHE_TTL= Duration.ofMinutes(5);
+    public static final Duration CONCERT_SEAT_LIST_CACHE_TTL= Duration.ofMinutes(5);
 
     /**
      * 콘서트 목록조회

--- a/src/main/java/io/hhplus/concert/domain/reservation/Reservation.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/Reservation.java
@@ -188,7 +188,7 @@ public class Reservation extends BaseEntity {
 		if(this.concertSeat.isAvailable()) return false;
 		// 에약 상태를 검증
 		// 좌석이 임시대기 상태인지확인
-		if(this.status != PENDING_PAYMENT)return false;
+		if(this.status != PENDING_PAYMENT) return false;
 		// 현재를 기준으로 좌석의 임시예약 만료일자가 아직 유효한지
 		if(DateValidator.isPastDateTime(this.tempReservationExpiredAt)) return false;
 		return true;
@@ -198,5 +198,16 @@ public class Reservation extends BaseEntity {
 		if(this.status != CONFIRMED) return false;
 		if(this.reservedAt == null) return false;
 		return true;
+	}
+
+	/**
+	 * 문제점: 만료를 재현시키다보니 테스트에서도 만료될때까지 기다려야되는 문제발생.
+	 * 만료일자를 지정하여 인스턴스함수로 만료상태로 변경하고자한다.
+	 */
+	public void expireTemporaryReserve(LocalDateTime expiredAt) {
+		if(!DateValidator.isPastDateTime(expiredAt))
+			throw new InvalidValidationException(EXPIRED_DATE_SHOULD_BE_PAST_DATETIME);
+		this.tempReservationExpiredAt = expiredAt;
+
 	}
 }

--- a/src/main/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceService.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceService.java
@@ -1,10 +1,17 @@
 package io.hhplus.concert.domain.reservation;
 
+import static io.hhplus.concert.domain.concert.ConcertService.*;
+import static io.hhplus.concert.domain.concert.ConcertService.CONCERT_SEAT_LIST_CACHE_TTL;
+
 import java.util.List;
 
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.hhplus.concert.domain.concert.ConcertInfo;
 import io.hhplus.concert.domain.concert.ConcertSeat;
 import io.hhplus.concert.domain.concert.ConcertSeatRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +21,9 @@ import lombok.RequiredArgsConstructor;
 public class ReservationMaintenanceService {
 	private final ReservationRepository reservationRepository;
 	private final ConcertSeatRepository concertSeatRepository;
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
 
 	/**
 	 * 임시예약 취소처리된 예약은 soft-delete 된다.
@@ -40,6 +50,14 @@ public class ReservationMaintenanceService {
 			// 만일 데이터가 없다면 해당 좌석의 상태값을 예약 가능으로 변경하고 저장한다
 			concertSeat.cancel();
 			concertSeatRepository.saveOrUpdate(concertSeat);
+
+			// 좌석의 상태가 변경되었으므로, 데이터베이스에서 좌석목록조회후에 캐시스토어에 바로 반영한다.
+			long concertId = concertSeat.getConcert().getId();
+			long concertDateId = concertSeat.getConcertDate().getId();
+			String cacheKey = CONCERT_SEAT_LIST_CACHE_KEY + "-" + "concert_id:" + concertId +"-" + "concert_date_id:" + concertDateId;
+
+			ConcertInfo.GetConcertSeatList concertSeats = concertSeatRepository.findConcertSeats(concertId, concertDateId);
+			redisTemplate.opsForValue().set(cacheKey, concertSeats, CONCERT_SEAT_LIST_CACHE_TTL);
 		}
 
 	}

--- a/src/main/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceService.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceService.java
@@ -3,6 +3,7 @@ package io.hhplus.concert.domain.reservation;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import io.hhplus.concert.domain.concert.ConcertSeat;
 import io.hhplus.concert.domain.concert.ConcertSeatRepository;
@@ -17,6 +18,7 @@ public class ReservationMaintenanceService {
 	/**
 	 * 임시예약 취소처리된 예약은 soft-delete 된다.
 	 */
+	@Transactional
 	public void deleteCanceledReservations() {
 		reservationRepository.deleteCanceledReservations();
 	}
@@ -24,6 +26,7 @@ public class ReservationMaintenanceService {
 	/**
 	 * 임시예약만료일자가 지나면 예약의 상태는 PENDING_PAYMENT -> CANCELED 로 취소 상태로 변경된다.
 	 */
+	@Transactional
 	public void cancel() {
 		// 임시예약 만료일자가 지난 예약정보를 가져온다
 		List<Reservation> expiredReservations = reservationRepository.findExpiredTempReservations();
@@ -31,7 +34,6 @@ public class ReservationMaintenanceService {
 		// 임시예약 만료일자가 이미 지난 예약들은 모두 취소상태로 변경한다
 		reservationRepository.updateCanceledExpiredTempReservations();
 
-		//
 		for(Reservation expiredReservation : expiredReservations) {
 			ConcertSeat concertSeat = expiredReservation.getConcertSeat();
 

--- a/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
@@ -24,14 +24,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final ConcertSeatRepository concertSeatRepository;
+    private static final String TEMPORARY_RESERVE_KEY = "'concertSeat:' + #command.concertSeat().id + ':temporaryReserve'";
 
     /**
      * 임시예약 상태
+     * 분산락 키 표기 - lock:concertSeat:{concertSeatId}:temporaryReserve
      * @param command
      * @return ReservationInfo.TemporaryReserve
      * @throws BusinessException
+     *
      */
-    @DistributedSimpleLock(key="#command.concertSeat().id", ttlSeconds = TEMPORARY_RESERVATION_DURATION_SECOND)
+    @DistributedSimpleLock(key=TEMPORARY_RESERVE_KEY, ttlSeconds = TEMPORARY_RESERVATION_DURATION_SECOND)
     @Transactional
     public ReservationInfo.TemporaryReserve temporaryReserve(ReservationCommand.TemporaryReserve command) {
         try{

--- a/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
+++ b/src/main/java/io/hhplus/concert/domain/reservation/ReservationService.java
@@ -48,6 +48,8 @@ public class ReservationService {
             reservation.temporaryReserve();
             // 임시예약 상태면 좌석도 점유되어있으므로 데이터베이스에 저장
             concertSeatRepository.saveOrUpdate(reservation.getConcertSeat());
+            // 좌석상태가 변경되었으므로, 좌석목록 캐시스토어에 바로 반영한다.
+
             // 임시예약 상태의 예약 정보를 데이터베이스에 저장
             reservationRepository.saveOrUpdate(reservation);
             return ReservationInfo.TemporaryReserve.from(reservation);

--- a/src/main/java/io/hhplus/concert/domain/token/TokenCommand.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenCommand.java
@@ -17,7 +17,7 @@ public record TokenCommand() {
 	}
 	public record GetTokenByUUID(UUID uuid) {
 		public static GetTokenByUUID of(UUID uuid) {
-			if(uuid != null) throw new InvalidValidationException(SHOULD_NOT_EMPTY);
+			if(uuid == null) throw new InvalidValidationException(SHOULD_NOT_EMPTY);
 			return new GetTokenByUUID(uuid);
 		}
 	}

--- a/src/main/java/io/hhplus/concert/domain/token/TokenScheduler.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenScheduler.java
@@ -6,4 +6,7 @@ public interface TokenScheduler {
 
 	// 대기열큐에서 대기중인 토큰중 만료된 토큰들은 삭제한다 (매 5분마다)
 	void removeExpiredWaitingTokensInWaitingQueue();
+
+	// 매 10초마다 폴링방식으로 대기상태토큰의 대기번호조회 및 토큰활성화
+	void pollWaitingTokens();
 }

--- a/src/main/java/io/hhplus/concert/domain/token/TokenService.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenService.java
@@ -10,9 +10,12 @@ import io.hhplus.concert.domain.user.User;
 import io.hhplus.concert.domain.user.UserRepository;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenService {
@@ -76,7 +79,7 @@ public class TokenService {
         // 이미 토큰이 activated 됐는지 확인
         if(token.isActivated()) throw new BusinessException(TOKEN_ALREADY_ISSUED);
         // 대기열큐에 존재하며, 대상토큰의 uuid가 대기열큐의 맨앞에있는지 확인
-        if( waitingQueue.contains(uuid) && (uuid != waitingQueue.peek()) )
+        if( waitingQueue.contains(uuid) && waitingQueue.peek() == uuid )
             throw new BusinessException(TOKEN_IS_WAITING);
 
         // 해당 uuid 를 큐에서 제거

--- a/src/main/java/io/hhplus/concert/domain/token/TokenService.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenService.java
@@ -71,8 +71,11 @@ public class TokenService {
         // 현재 토큰의 대기순서를 알려준다.
         int position = waitingQueue.getPosition(token.getUuid());
 
-        // 토큰을 저장한다
+        // DB에 토큰정보를 저장한다
         tokenRepository.saveOrUpdate(token);
+        // 캐시를 동기화한다(write-through)
+        String tokenKey = TOKEN_CACHE_KEY + token.getUuid().toString();
+        redisTemplate.opsForValue().set(tokenKey, token, TOKEN_CACHE_TTL);
 
         // 토큰정보와 대기순서를 같이 리턴한다
         return TokenInfo.IssueWaitingToken.of(token, position);

--- a/src/main/java/io/hhplus/concert/domain/token/TokenService.java
+++ b/src/main/java/io/hhplus/concert/domain/token/TokenService.java
@@ -1,5 +1,6 @@
 package io.hhplus.concert.domain.token;
 
+import static io.hhplus.concert.domain.token.Token.*;
 import static io.hhplus.concert.interfaces.api.token.TokenErrorCode.*;
 
 import java.time.Duration;
@@ -26,7 +27,7 @@ public class TokenService {
     private final ObjectMapper objectMapper;
 
     private static final String TOKEN_CACHE_KEY= "token:";
-    private static final Duration TOKEN_CACHE_TTL = Duration.ofMinutes(5);
+    private static final Duration TOKEN_CACHE_TTL = Duration.ofMinutes(VALID_TOKEN_DURATION_MINUTE_UNIT);
 
 
     public TokenInfo.GetTokenByUUID getTokenByUUID(TokenCommand.GetTokenByUUID command) {

--- a/src/main/java/io/hhplus/concert/domain/user/UserInfo.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserInfo.java
@@ -1,10 +1,17 @@
 package io.hhplus.concert.domain.user;
 
+import java.util.List;
 
 public class UserInfo {
-	public record GetCurrentPoint(long point){
-		public static GetCurrentPoint of(long point) {
-			return new GetCurrentPoint(point);
+	public record GetCurrentPoint(
+		long point, // 현재포인트
+		List<UserPointHistory> histories // 히스토리
+	){
+		public static GetCurrentPoint of(UserPoint userPoint) {
+			return new GetCurrentPoint(
+				userPoint.getPoint(),
+				userPoint.getHistories()
+			);
 		}
 	}
 	public record GetUserPoint(UserPoint userPoint) {

--- a/src/main/java/io/hhplus/concert/domain/user/UserPoint.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserPoint.java
@@ -2,6 +2,7 @@ package io.hhplus.concert.domain.user;
 
 
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
+import static io.hhplus.concert.interfaces.api.user.UserErrorCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,7 +83,15 @@ public class UserPoint{
 
 		point = point + amount; // 포인트 계산
 		histories.add(UserPointHistory.of(this, amount, UserPointHistoryStatus.CHARGE)); // 충전내역기록
+	}
+	public UserPointHistory getLatestUserPointHistory() {
+		try {
+			int latestIdx = this.histories.size() -1;
+			return this.histories.get(latestIdx);
 
+		} catch(IndexOutOfBoundsException e) {
+			throw new BusinessException(EMPTY_POINT_HISTORIES);
+		}
 	}
 
 	/**

--- a/src/main/java/io/hhplus/concert/domain/user/UserPointHistory.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserPointHistory.java
@@ -53,7 +53,7 @@ public class UserPointHistory extends BaseEntity {
 
     /**
      * 정적 팩토리 메소드로 포인트히스토리 추가
-     * @param user
+     * @param userPoint
      * @param amount
      * @param status
      * @return UserPointHistory

--- a/src/main/java/io/hhplus/concert/domain/user/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserService.java
@@ -31,8 +31,11 @@ public class UserService {
         // amount 값만큼 포인트 충전
         userPoint.charge(command.amount());
 
-        // 유저 포인트 + 포인트 내역 저장
+        // 유저 포인트 저장
         userPointRepository.save(userPoint);
+        // 유저포인트 가장 최근 히스토리 저장
+        UserPointHistory latestHistory = userPoint.getLatestUserPointHistory();
+        userPointHistoryRepository.save(latestHistory);
 
         // 충전후 유저정보를 리턴
        return UserInfo.ChargePoint.of(userPoint.getPoint());
@@ -52,24 +55,22 @@ public class UserService {
         // amount 값만큼 포인트 사용
         userPoint.use(command.amount());
 
-        // 유저 포인트 + 포인트 내역 저장
+        // 유저 포인트 저장
         userPointRepository.save(userPoint);
+        // 유저포인트 가장 최근 히스토리 저장
+        UserPointHistory latestHistory = userPoint.getLatestUserPointHistory();
+        userPointHistoryRepository.save(latestHistory);
 
         // 사용후 포인트정보를 리턴
         return  UserInfo.UsePoint.of(userPoint.getPoint());
     }
-    /**
-     * 식별자(id)로 유저 도메인 엔티티를 호출
-     *
-     * @param command
-     * @return UserInfo.UserPoint
-     */
+
     public UserInfo.GetCurrentPoint getCurrentPoint(UserPointCommand.GetCurrentPoint command) {
         UserPoint userPoint = userPointRepository.findByUserId(command.userId());
         if(userPoint == null) throw new BusinessException(UserErrorCode.NOT_EXIST_USER);
-        return UserInfo.GetCurrentPoint.of(userPoint.getPoint());
+        return UserInfo.GetCurrentPoint.of(userPoint);
     }
-
+    @Transactional
     public UserInfo.GetUserPoint getUserPoint(UserPointCommand.GetUserPoint command) {
         UserPoint userPoint = userPointRepository.findUserPointWithExclusiveLock(command.userId());
         if(userPoint == null) throw new BusinessException(UserErrorCode.NOT_EXIST_USER);

--- a/src/main/java/io/hhplus/concert/domain/user/UserService.java
+++ b/src/main/java/io/hhplus/concert/domain/user/UserService.java
@@ -71,7 +71,7 @@ public class UserService {
     }
 
     public UserInfo.GetUserPoint getUserPoint(UserPointCommand.GetUserPoint command) {
-        UserPoint userPoint = userPointRepository.findByUserId(command.userId());
+        UserPoint userPoint = userPointRepository.findUserPointWithExclusiveLock(command.userId());
         if(userPoint == null) throw new BusinessException(UserErrorCode.NOT_EXIST_USER);
         return UserInfo.GetUserPoint.of(userPoint);
     }

--- a/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedLockAspect.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedLockAspect.java
@@ -1,0 +1,81 @@
+package io.hhplus.concert.infrastructure.distributedlock;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.UUID;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import io.hhplus.concert.interfaces.api.common.DistributedLockException;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@Order(0) // 트랜잭션보다 먼저 실행되도록 가장 앞 순서로 한다.
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Around("@annotation(distributedLock)")
+	public Object around(ProceedingJoinPoint joinPoint, DistributedSimpleLock distributedLock) throws Throwable {
+		String key = generateDistributedLockKey(joinPoint, distributedLock);
+		String lockValue = UUID.randomUUID().toString();
+		Duration timeout = Duration.ofSeconds(distributedLock.ttlSeconds());
+
+		// 락 획득 시도(SETNX + EXPIRE)
+		Boolean success = redisTemplate.opsForValue().setIfAbsent(key, lockValue, timeout);
+		if(Boolean.FALSE.equals(success)) {
+			throw new DistributedLockException("Lock failed for key: "+ key);
+		}
+
+		try {
+			return joinPoint.proceed(); // 실제서비스 메서드 수행
+		} finally {
+			unlock(key, lockValue);
+		}
+	}
+
+	private void unlock(String key, String value) {
+		String rawLuaScript = """
+		if redis.call("get", KEYS[1]) == ARGV[1] then
+			return redis.call("del", KEYS[1])
+		else
+			return 0
+		end
+		""";
+		redisTemplate.execute(
+			new DefaultRedisScript<>(rawLuaScript,  Long.class),
+			Collections.singletonList(key),
+			value
+		);
+	}
+
+	private String generateDistributedLockKey(ProceedingJoinPoint joinPoint, DistributedSimpleLock distributedLock) {
+		Object[] args = joinPoint.getArgs();
+		Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+
+		ExpressionParser parser = new SpelExpressionParser();
+		EvaluationContext context = new StandardEvaluationContext();
+
+		String[] paramNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();
+		for(int i=0; i<args.length; i++) {
+			context.setVariable(paramNames[i], args[i]);
+		}
+		Expression expression = parser.parseExpression(distributedLock.key());
+		String evaluatedKey = expression.getValue(context, String.class);
+		return "lock:"+evaluatedKey;
+	}
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSimpleLock.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSimpleLock.java
@@ -1,0 +1,13 @@
+package io.hhplus.concert.infrastructure.distributedlock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedSimpleLock {
+	String key();
+	int ttlSeconds() default 5; // 기본 TTL은 5초로한다.
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSimpleLockAspect.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSimpleLockAspect.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @Order(0) // 트랜잭션보다 먼저 실행되도록 가장 앞 순서로 한다.
 @RequiredArgsConstructor
-public class DistributedLockAspect {
+public class DistributedSimpleLockAspect {
 	private final RedisTemplate<String, String> redisTemplate;
 
 	@Around("@annotation(distributedLock)")

--- a/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSpinLock.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSpinLock.java
@@ -1,0 +1,15 @@
+package io.hhplus.concert.infrastructure.distributedlock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedSpinLock {
+	String key();
+	int ttlSeconds() default 5; // 락점유시간: 기본 5초
+	int waitSeconds() default 5; // 다른스레드가 대기하는 시간: 기본 5초
+	int retryMillis() default 100; // 재시도를 하기위한 대기시간: 기본 100ms
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSpinLockAspect.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/distributedlock/DistributedSpinLockAspect.java
@@ -1,0 +1,62 @@
+package io.hhplus.concert.infrastructure.distributedlock;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import io.hhplus.concert.interfaces.api.common.DistributedLockException;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@Order(0)
+@RequiredArgsConstructor
+public class DistributedSpinLockAspect {
+	private final SpinLockManager lockManager;
+
+	@Around("@annotation(lock)")
+	public Object around(ProceedingJoinPoint joinPoint, DistributedSpinLock lock) throws Throwable {
+		String key = generateKey(joinPoint, lock);
+		String value = UUID.randomUUID().toString();
+
+		Duration ttl = Duration.ofSeconds(lock.ttlSeconds());
+		Duration wait = Duration.ofSeconds(lock.waitSeconds());
+		Duration retry = Duration.ofMillis(lock.retryMillis());
+
+		boolean acquired = lockManager.tryLock(key, value, ttl, wait, retry);
+		if(!acquired) {
+			throw new DistributedLockException("SpinLock 획득 실패: " + key);
+		}
+
+		try {
+			return joinPoint.proceed();
+		} finally {
+			lockManager.unlock(key, value);
+		}
+	}
+
+	private String generateKey(ProceedingJoinPoint joinPoint, DistributedSpinLock lock) {
+		Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+		EvaluationContext context = new StandardEvaluationContext();
+		String[] paramNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();
+		Object[] args = joinPoint.getArgs();
+
+		for(int i=0; i<args.length; i++)
+			context.setVariable(paramNames[i], args[i]);
+
+		Expression expression = new SpelExpressionParser().parseExpression(lock.key());
+		return "lock:" + expression.getValue(context, String.class);
+	}
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/distributedlock/SpinLockManager.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/distributedlock/SpinLockManager.java
@@ -1,0 +1,50 @@
+package io.hhplus.concert.infrastructure.distributedlock;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SpinLockManager {
+	private final RedisTemplate<String, String> redisTemplate;
+	private static final String LOCK_PREFIX = "lock:";
+
+	public boolean tryLock(String key, String value, Duration ttl, Duration waitTimeout, Duration retryInterval) {
+		long deadLine = System.currentTimeMillis() + waitTimeout.toMillis();
+		while(System.currentTimeMillis() <= deadLine) {
+			Boolean success = redisTemplate.opsForValue().setIfAbsent(key, value, ttl);
+			if(Boolean.TRUE.equals(success)) return true;
+
+			try {
+				Thread.sleep(retryInterval.toMillis());
+			} catch(InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	public void unlock(String key, String value) {
+		String script = """
+			if redis.call('get', KEYS[1]) == ARGV[1] then
+				return redis.call('del', KEYS[1])
+			else
+				return 0
+			end
+		""";
+
+		redisTemplate.execute(
+			new DefaultRedisScript<>(script, Long.class),
+			Collections.singletonList(key),
+			value
+		);
+	}
+}

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertDateRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertDateRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import io.hhplus.concert.domain.concert.ConcertDate;
 import io.hhplus.concert.domain.concert.ConcertDateRepository;
+import io.hhplus.concert.domain.concert.ConcertInfo;
 import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
@@ -16,8 +17,9 @@ public class ConcertDateRepositoryImpl implements ConcertDateRepository {
     private final ConcertDateJpaRepository concertDateJpaRepository;
 
     @Override
-    public List<ConcertDate> findAllAvailable(long concertId) {
-        return concertDateJpaRepository.findUpcomingConcertDates(concertId, LocalDate.now());
+    public ConcertInfo.GetConcertDateList findAllAvailable(long concertId) {
+        List<ConcertDate> concertDates = concertDateJpaRepository.findUpcomingConcertDates(concertId, LocalDate.now());
+        return ConcertInfo.GetConcertDateList.from(concertDates);
     }
 
     @Override

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import io.hhplus.concert.domain.concert.Concert;
+import io.hhplus.concert.domain.concert.ConcertInfo;
 import io.hhplus.concert.domain.concert.ConcertRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -16,8 +17,9 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     private final ConcertJpaRepository concertJpaRepository;
 
     @Override
-    public List<Concert> findAll() {
-        return concertJpaRepository.findAll();
+    public ConcertInfo.GetConcertList findAll() {
+        List<Concert> concerts = concertJpaRepository.findAll();
+        return ConcertInfo.GetConcertList.from(concerts);
     }
 
     @Override

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertSeatRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/concert/ConcertSeatRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import io.hhplus.concert.domain.concert.ConcertInfo;
 import io.hhplus.concert.domain.concert.ConcertSeat;
 import io.hhplus.concert.domain.concert.ConcertSeatRepository;
 
@@ -17,8 +18,9 @@ public class ConcertSeatRepositoryImpl implements ConcertSeatRepository {
     private final ConcertSeatJpaRepository concertSeatJpaRepository;
 
     @Override
-    public List<ConcertSeat> findConcertSeats(long concertId, long concertDateId) {
-        return concertSeatJpaRepository.findAllSeats(concertId, concertDateId);
+    public ConcertInfo.GetConcertSeatList findConcertSeats(long concertId, long concertDateId) {
+        List<ConcertSeat> concertSeats =  concertSeatJpaRepository.findAllSeats(concertId, concertDateId);
+        return ConcertInfo.GetConcertSeatList.from(concertSeats);
     }
 
     @Override

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/token/TokenRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/token/TokenRepositoryImpl.java
@@ -1,18 +1,13 @@
 package io.hhplus.concert.infrastructure.persistence.token;
 
-import static io.hhplus.concert.interfaces.api.token.TokenErrorCode.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import io.hhplus.concert.domain.token.Token;
 import io.hhplus.concert.domain.token.TokenRepository;
-import io.hhplus.concert.interfaces.api.common.BusinessException;
 import lombok.RequiredArgsConstructor;
 
 @Repository

--- a/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserPointRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/persistence/user/UserPointRepositoryImpl.java
@@ -28,7 +28,6 @@ public class UserPointRepositoryImpl implements UserPointRepository {
 	}
 
 	@Override
-	@Transactional
 	public UserPoint findUserPointWithExclusiveLock(long userId) {
 		return userPointJpaRepository.findUserPointWithExclusiveLock(userId);
 	}

--- a/src/main/java/io/hhplus/concert/infrastructure/scheduler/TokenSchedulerImpl.java
+++ b/src/main/java/io/hhplus/concert/infrastructure/scheduler/TokenSchedulerImpl.java
@@ -6,13 +6,18 @@ import java.util.UUID;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import io.hhplus.concert.application.usecase.token.TokenCriteria;
+import io.hhplus.concert.application.usecase.token.TokenUsecase;
 import io.hhplus.concert.domain.token.TokenMaintenanceService;
 import io.hhplus.concert.domain.token.TokenScheduler;
+import io.hhplus.concert.domain.token.WaitingQueue;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class TokenSchedulerImpl implements TokenScheduler {
+	private final WaitingQueue waitingQueue;
+	private final TokenUsecase tokenUsecase;
 	private final TokenMaintenanceService tokenMaintenanceService;
 
 	@Scheduled(cron = "0 0 0 * * *")
@@ -25,5 +30,20 @@ public class TokenSchedulerImpl implements TokenScheduler {
 	@Override
 	public void removeExpiredWaitingTokensInWaitingQueue() {
 		tokenMaintenanceService.removeExpiredWaitingTokensInWaitingQueue();
+	}
+
+	@Scheduled(cron = "*/10 * * * * *")
+	@Override
+	public void pollWaitingTokens() {
+		List<UUID> uuids = waitingQueue.toList();
+		
+		// 상위100개만을 폴링방식으로 호출하여 토큰을 활성화시킨다.
+		if(uuids.size() >= 100 ) uuids = uuids.subList(0, 100);
+
+		for(UUID uuid : uuids) {
+			tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
+				TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(uuid)
+			);
+		}
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/DistributedLockException.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/DistributedLockException.java
@@ -1,0 +1,9 @@
+package io.hhplus.concert.interfaces.api.common;
+
+public class DistributedLockException extends RuntimeException {
+	private String message;
+	public DistributedLockException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/common/LoggingInterceptor.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/common/LoggingInterceptor.java
@@ -1,0 +1,34 @@
+package io.hhplus.concert.interfaces.api.common;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+	private static final String START_TIME = "start_time";
+
+	@Override
+	public boolean preHandle(HttpServletRequest request,  HttpServletResponse response, Object handler) {
+		long startTime = System.currentTimeMillis();
+		request.setAttribute(START_TIME, startTime);
+		log.info(":::: [REQUEST] {} {} from IP {}", request.getMethod(), request.getRequestURI(), request.getRemoteAddr());
+		log.info(":::: [HEADER] token={}", request.getHeader("token")); // 토큰 로깅
+		return true;
+	}
+	@Override
+	public void afterCompletion(HttpServletRequest request,  HttpServletResponse response, Object handler, Exception ex) {
+		long startTime = (Long) request.getAttribute(START_TIME);
+		long endTime = System.currentTimeMillis();
+		long duration = endTime - startTime;
+
+		log.info(":::: [RESPONSE] {} {} Status={} Duration={}ms", request.getMethod(), request.getRequestURI(), response.getStatus(), duration);
+
+		if(ex != null)
+			log.info(":::: [EXCEPTION] ", ex);
+	}
+}

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertController.java
@@ -35,7 +35,7 @@ public class ConcertController implements ConcertApiDocs {
 		// 리스트를 반환
 		ConcertInfo.GetConcertList info = concertService.getConcertList();
 		// 페이징처리를 한다
-		Page<Concert> concertPages = PaginationUtils.toPage(info.concerts(), page);
+		Page<ConcertInfo.GetConcertListDto> concertPages = PaginationUtils.toPage(info.concerts(), page);
 		// 페이징처리결과를 응답데이터에 넣어서 응답
 		return ApiResponseEntity.ok(ConcertResponse.GetConcerts.from(concertPages));
 	}

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertController.java
@@ -50,7 +50,7 @@ public class ConcertController implements ConcertApiDocs {
 		// 리스트를 반환
 		ConcertInfo.GetConcertDateList info = concertService.getConcertDateList(ConcertCommand.GetConcertDateList.of(id));
 		// 페이징처리를 한다
-		Page<ConcertDate> concertDatePage = PaginationUtils.toPage(info.concertDates(), page);
+		Page<ConcertInfo.GetConcertDateListDto> concertDatePage = PaginationUtils.toPage(info.concertDates(), page);
 		// 페이징처리 결과를 응답데이터에 넣고 응답한다
 		return ApiResponseEntity.ok(ConcertResponse.GetAvailableConcertDates.from(concertDatePage));
 	}

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
@@ -24,7 +24,7 @@ public record ConcertResponse(long id, String name, String artistName) { // Page
 	 * @param concertSeatList - 콘서트 좌석리스트
 	 */
 	public record GetAvailableSeats (
-		List<ConcertSeat> concertSeatList
+		List<ConcertInfo.ConcertSeatListDto> concertSeatList
 	) {
 		public static GetAvailableSeats from(ConcertInfo.GetConcertSeatList info) {
 			return new GetAvailableSeats(info.concertSeatList());

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
@@ -65,13 +65,13 @@ public record ConcertResponse(long id, String name, String artistName) { // Page
 	 * @param currentSize - 현재 페이지의 공연일정 개수
 	 */
 	public record GetAvailableConcertDates(
-		List<ConcertDate> concertDates,
+		List<ConcertInfo.GetConcertDateListDto> concertDates,
 		long totalElements,
 		int totalPages,
 		int currentPage,
 		int currentSize
 	) {
-		public static GetAvailableConcertDates from(Page<ConcertDate> concertDatePage) { // from절에는 페이징처리 결과를 넣으면 된다.
+		public static GetAvailableConcertDates from(Page<ConcertInfo.GetConcertDateListDto> concertDatePage) { // from절에는 페이징처리 결과를 넣으면 된다.
 
 			return new GetAvailableConcertDates(
 				concertDatePage.getContent(),

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
@@ -39,13 +39,13 @@ public record ConcertResponse(long id, String name, String artistName) { // Page
 	 * @param currentSize - 현재 페이지의 공연 개수
 	 */
 	public record GetConcerts(
-		List<Concert> concerts,
+		List<ConcertInfo.GetConcertListDto> concerts,
 		long totalElements,
 		int totalPages,
 		int currentPage,
 		int currentSize
 	) {
-		public static GetConcerts from(Page<Concert> concertPage) {
+		public static GetConcerts from(Page<ConcertInfo.GetConcertListDto> concertPage) {
 			return new GetConcerts(
 				concertPage.getContent(),
 				concertPage.getTotalElements(),

--- a/src/main/java/io/hhplus/concert/interfaces/api/reservation/ReservationErrorCode.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/reservation/ReservationErrorCode.java
@@ -15,6 +15,7 @@ public enum ReservationErrorCode implements BusinessErrorCode {
 	 ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 좌석은 이미 예약이 되었습니다."),
 	 NOT_FOUND_RESERVATION(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다"),
 	 INVALID_RESERVATION_STATUS (HttpStatus.BAD_REQUEST, "적합하지 않은 상태정보 입니다"),
+	 EXPIRED_DATE_SHOULD_BE_PAST_DATETIME (HttpStatus.BAD_REQUEST, "만료일자는 반드시 과거날짜여야 합니다."),
 	 INVALID_INPUT_DATA( HttpStatus.BAD_REQUEST, "입력데이터가 적절하지 않습니다."),
 	 TEMPORARY_RESERVATION_ALREADY_EXPIRED(
 		 HttpStatus.REQUEST_TIMEOUT, "유효시간 "+TEMPORARY_RESERVATION_DURATION_MINUTE+"분이 이미 지났으므로, 해당 예약은 이미 만료되었습니다"

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/TokenController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/TokenController.java
@@ -40,7 +40,7 @@ public class TokenController implements TokenApiDocs {
 	) {
 		TokenResult.GetWaitingTokenPositionAndActivateWaitingToken result =
 			tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
-				TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(request.userId())
+				TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(request.uuid())
 			);
 		return ApiResponseEntity.ok(TokenResponse.GetWaitingTokenPositionAndActivateWaitingToken.of(result));
 	}

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/TokenHandlerInterceptor.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/TokenHandlerInterceptor.java
@@ -4,6 +4,7 @@ import static io.hhplus.concert.interfaces.api.token.TokenErrorCode.*;
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -27,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TokenHandlerInterceptor implements HandlerInterceptor {
 	private final TokenService tokenService;
+	private final ObjectMapper objectMapper;
 
 
 	@Override
@@ -60,13 +62,9 @@ public class TokenHandlerInterceptor implements HandlerInterceptor {
 		response.setStatus(status.value());
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		response.setCharacterEncoding("UTF-8");
-		String body = """
-			{
-				"status": %d,
-				"message": "%s"
-			}
-			""".formatted(status.value(), message);
-		response.getWriter().write(body);
 
+		ErrorResponse errorResponse = ErrorResponse.of(status.value(), message);
+		String json = objectMapper.writeValueAsString(errorResponse);
+		response.getOutputStream().write(json.getBytes(StandardCharsets.UTF_8));
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/TokenRequest.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/TokenRequest.java
@@ -10,9 +10,9 @@ public record TokenRequest() {
 			return new IssueWaitingToken(userId);
 		}
 	}
-	public record GetWaitingTokenPositionAndActivateWaitingToken(long userId) {
-		public static GetWaitingTokenPositionAndActivateWaitingToken of(long userId, UUID uuid) {
-			return new GetWaitingTokenPositionAndActivateWaitingToken(userId);
+	public record GetWaitingTokenPositionAndActivateWaitingToken(UUID uuid) {
+		public static GetWaitingTokenPositionAndActivateWaitingToken of(UUID uuid) {
+			return new GetWaitingTokenPositionAndActivateWaitingToken(uuid);
 		}
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/token/WebMvcConfig.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/token/WebMvcConfig.java
@@ -14,16 +14,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import io.hhplus.concert.interfaces.api.common.ErrorResponse;
+import io.hhplus.concert.interfaces.api.common.LoggingInterceptor;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 	private final TokenHandlerInterceptor tokenInterceptor;
+	private final LoggingInterceptor loggingInterceptor;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
+		// 로깅인터셉터
+		registry.addInterceptor(loggingInterceptor)
+			.order(1)
+			.addPathPatterns("/**");
+
+		// 토큰인터셉터
 		registry.addInterceptor(tokenInterceptor)
+			.order(2)
 			.addPathPatterns("/**") // 전체 대상
 			.excludePathPatterns("/concerts/**", "/tokens/**", "/users/account"); // 해당 API 는 인터셉터 검증을 제외한다
 	}

--- a/src/main/java/io/hhplus/concert/interfaces/api/user/PointResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/user/PointResponse.java
@@ -1,6 +1,9 @@
 package io.hhplus.concert.interfaces.api.user;
 
+import java.util.List;
+
 import io.hhplus.concert.domain.user.UserInfo;
+import io.hhplus.concert.domain.user.UserPointHistory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,9 +15,13 @@ public record PointResponse() {
 			return new ChargePoint(info.point());
 		}
 	}
-	public record GetCurrentPoint(long point) {
+	public record GetCurrentPoint(
+		long point,
+		List<UserPointHistory> histories
+	) {
 		public static GetCurrentPoint from(UserInfo.GetCurrentPoint info) {
-			return new GetCurrentPoint(info.point());
+
+			return new GetCurrentPoint(info.point(), info.histories());
 		}
 	}
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/user/UserController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/user/UserController.java
@@ -15,6 +15,7 @@ import io.hhplus.concert.domain.user.UserPointCommand;
 import io.hhplus.concert.domain.user.UserService;
 import io.hhplus.concert.interfaces.api.common.ApiResponse;
 import io.hhplus.concert.interfaces.api.common.ApiResponseEntity;
+import io.hhplus.concert.interfaces.api.token.UserContextHolder;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -47,9 +48,10 @@ public class UserController implements UserPointApiDocs {
 	public ResponseEntity<ApiResponse<PointResponse.GetCurrentPoint>> getPoint(
 		@RequestHeader("token") @Valid String token
 	) {
-		// 토큰을 통해서 userId 를 추출.
-		long userId = 1L;
-		UserInfo.GetCurrentPoint result = userService.getCurrentPoint(UserPointCommand.GetCurrentPoint.of(userId));
+		long userId = UserContextHolder.get().getUserId();
+		UserInfo.GetCurrentPoint result = userService.getCurrentPoint(
+			UserPointCommand.GetCurrentPoint.of(userId)
+		);
 		PointResponse.GetCurrentPoint response = PointResponse.GetCurrentPoint.from(result);
 		return ApiResponseEntity.ok(response);
 	}

--- a/src/main/java/io/hhplus/concert/interfaces/api/user/UserErrorCode.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/user/UserErrorCode.java
@@ -21,7 +21,8 @@ public enum UserErrorCode implements BusinessErrorCode {
 	CHARGE_AMOUNT_SHOULD_BE_MORE_THAN_MINIMUM(HttpStatus.BAD_REQUEST, "충전금액의 최소값("+CHARGE_POINT_MINIMUM+"원)보다 커야 합니다."),
 	CHARGE_AMOUNT_SHOULD_BE_LESS_THAN_MAXIMUM(HttpStatus.BAD_REQUEST, "충전금액의 최대값("+CHARGE_POINT_MAXIMUM+"원)보다 작아야 합니다."),
 	LACK_OF_YOUR_POINT(HttpStatus.BAD_REQUEST, "잔액이 부족합니다."),
-	NOT_EXIST_USER(HttpStatus.NOT_FOUND, "존재하지 않은 유저입니다.")
+	NOT_EXIST_USER(HttpStatus.NOT_FOUND, "존재하지 않은 유저입니다."),
+	EMPTY_POINT_HISTORIES(HttpStatus.BAD_REQUEST, "포인트 내역이 비어있습니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,13 +22,14 @@ spring:
       hibernate.jdbc.time_zone: UTC
 
 ---
-spring.config.activate.on-profile: local, test
-
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+  redis:
+    host: localhost
+    port: 6379
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/src/test/java/io/hhplus/concert/RedisTestContainerConfiguration.java
+++ b/src/test/java/io/hhplus/concert/RedisTestContainerConfiguration.java
@@ -1,0 +1,24 @@
+package io.hhplus.concert;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+@TestConfiguration
+public class RedisTestContainerConfiguration {
+	@Container
+	public static final GenericContainer<?> redisContainer = new GenericContainer<>("redis")
+		.withExposedPorts(6379);
+
+	static {
+		redisContainer.start();
+	}
+
+	@DynamicPropertySource
+	static void redisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.redis.host", redisContainer::getHost);
+		registry.add("spring.redis.port", () -> redisContainer.getMappedPort(6379));
+	}
+}

--- a/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
@@ -118,9 +118,11 @@ public class PayAndConfirmTest {
 
 		long reservationId = 1L;
 		Reservation reservation = Reservation.of(user,concert,concertDate, concertSeat);
-		reservation.temporaryReserve(); // 임시예약상태
-		log.info("6분 대기하여 예약기간이 만료되어 취소처리됨");
-		Thread.sleep(6 * 60 * 1000);
+		// 임시예약상태
+		reservation.temporaryReserve();
+		// 임시예약상태를 만료시킨다.
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+
 		reservation.cancel(); // 취소처리
 		ReservationCommand.Get getReservationCommand = ReservationCommand.Get.of(reservationId);
 		when(reservationService.get(getReservationCommand)).thenReturn(ReservationInfo.Get.from(reservation));

--- a/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/payment/PayAndConfirmTest.java
@@ -172,6 +172,10 @@ public class PayAndConfirmTest {
 		when(reservationService.get(getReservationCommand)).thenReturn(ReservationInfo.Get.from(reservation));
 
 		log.info("결제 내역 데이터 생성");
+		userPoint.use(concertSeat.getPrice());
+		UserPointCommand.UsePoint usePointCommand = UserPointCommand.UsePoint.of(userId, concertSeat.getPrice());
+		when(userService.usePoint(usePointCommand)).thenReturn(UserInfo.UsePoint.of(userPoint.getPoint()));
+
 		Payment payment = Payment.of(reservation);
 		PaymentCommand.CreatePayment createPaymentCommand = PaymentCommand.CreatePayment.of(reservation);
 		when(paymentService.create(createPaymentCommand)).thenReturn(PaymentInfo.CreatePayment.of(payment));

--- a/src/test/java/io/hhplus/concert/application/usecase/payment/PaymentAndConfirmConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/payment/PaymentAndConfirmConcurrencyIntegrationTest.java
@@ -1,10 +1,12 @@
-package io.hhplus.concert.domain.payment;
+package io.hhplus.concert.application.usecase.payment;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -16,18 +18,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
-import io.hhplus.concert.application.usecase.payment.PaymentCriteria;
-import io.hhplus.concert.application.usecase.payment.PaymentResult;
-import io.hhplus.concert.application.usecase.payment.PaymentUsecase;
 import io.hhplus.concert.domain.concert.Concert;
 import io.hhplus.concert.domain.concert.ConcertDate;
 import io.hhplus.concert.domain.concert.ConcertDateRepository;
 import io.hhplus.concert.domain.concert.ConcertRepository;
 import io.hhplus.concert.domain.concert.ConcertSeat;
 import io.hhplus.concert.domain.concert.ConcertSeatRepository;
+import io.hhplus.concert.domain.payment.Payment;
+import io.hhplus.concert.domain.payment.PaymentRepository;
+import io.hhplus.concert.domain.payment.PaymentService;
 import io.hhplus.concert.domain.reservation.Reservation;
 import io.hhplus.concert.domain.reservation.ReservationCommand;
 import io.hhplus.concert.domain.reservation.ReservationInfo;
@@ -43,6 +46,7 @@ import io.hhplus.concert.domain.user.UserRepository;
 import io.hhplus.concert.domain.user.UserService;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {
 	"SET FOREIGN_KEY_CHECKS=0",

--- a/src/test/java/io/hhplus/concert/application/usecase/payment/PaymentUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/payment/PaymentUsecaseIntegrationTest.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
@@ -48,6 +49,7 @@ import io.hhplus.concert.interfaces.api.common.BusinessException;
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {
 	"SET FOREIGN_KEY_CHECKS=0",

--- a/src/test/java/io/hhplus/concert/application/usecase/reservation/ReservationUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/reservation/ReservationUsecaseIntegrationTest.java
@@ -70,7 +70,7 @@ public class ReservationUsecaseIntegrationTest {
 	User sampleUser;
 	@BeforeEach
 	void setUp() {
-		// truncate -> serUp -> 테스트케이스 수행 순으로 진행
+		// truncate -> setUp -> 테스트케이스 수행 순으로 진행
 		// 유저 테스트 데이터 셋팅
 		sampleUser = User.of("최은강");
 		userRepository.save(sampleUser);

--- a/src/test/java/io/hhplus/concert/application/usecase/reservation/ReservationUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/reservation/ReservationUsecaseIntegrationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
@@ -35,6 +36,7 @@ import io.hhplus.concert.domain.user.UserService;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {

--- a/src/test/java/io/hhplus/concert/application/usecase/token/TokenUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/token/TokenUsecaseIntegrationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
@@ -25,6 +26,7 @@ import io.hhplus.concert.domain.user.User;
 import io.hhplus.concert.domain.user.UserRepository;
 import io.hhplus.concert.domain.user.UserService;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {

--- a/src/test/java/io/hhplus/concert/application/usecase/token/TokenUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/usecase/token/TokenUsecaseIntegrationTest.java
@@ -1,0 +1,163 @@
+package io.hhplus.concert.application.usecase.token;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import io.hhplus.concert.TestcontainersConfiguration;
+import io.hhplus.concert.domain.token.Token;
+import io.hhplus.concert.domain.token.TokenRepository;
+import io.hhplus.concert.domain.token.TokenService;
+import io.hhplus.concert.domain.token.TokenStatus;
+import io.hhplus.concert.domain.token.WaitingQueue;
+import io.hhplus.concert.domain.user.User;
+import io.hhplus.concert.domain.user.UserRepository;
+import io.hhplus.concert.domain.user.UserService;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Sql(statements = {
+	"SET FOREIGN_KEY_CHECKS=0",
+	"TRUNCATE TABLE tokens",
+	"TRUNCATE TABLE users",
+	"SET FOREIGN_KEY_CHECKS=1"
+}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TokenUsecaseIntegrationTest {
+	@Autowired private TokenUsecase tokenUsecase;
+	@Autowired private TokenService tokenService;
+	@Autowired private UserService userService;
+
+	@Autowired private UserRepository userRepository;
+	@Autowired private TokenRepository tokenRepository;
+	@Autowired private WaitingQueue waitingQueue;
+
+	UUID sampleUserUUID;
+	User sampleUser;
+	Token sampleWaitingToken;
+
+	@BeforeEach
+	void setUp() {
+		// truncate -> setUp -> 테스트케이스 수행순으로 진행
+		// 대기 토큰을 비운다
+		waitingQueue.clear();
+
+		// 테스트 유저 데이터 초기셋팅
+		sampleUser = userRepository.save(User.of("테스트 유저"));
+	}
+
+	/**
+	 * issueWaitingToken
+	 */
+	@Order(1)
+	@Test
+	void 신규_대기상태토큰_발급을_요청한다() {
+		// when
+		TokenResult.IssueWaitingToken tokenResult = tokenUsecase.issueWaitingToken(TokenCriteria.IssueWaitingToken.of(sampleUser.getId()));
+
+		// then
+		assertNotNull(tokenResult.token()); // 응답값의 토큰은 null이 아니다.
+		assertNotNull(tokenResult.user()); // 응답값의 유저는 null이 아니다.
+
+		assertEquals(sampleUser.getName(), tokenResult.token().getUser().getName()); // 응답값의 유저는 테스트유저이다.
+
+		assertEquals(1, tokenResult.position());// 대기열큐의 1번이다.
+		assertTrue(waitingQueue.contains(tokenResult.token().getUuid())); // 대기열큐에 uuid가 들어있음
+		assertEquals(TokenStatus.WAITING, tokenResult.token().getStatus());// 토큰의 현재상태는 대기상태이다.
+		assertFalse(tokenResult.token().isExpiredToken());// 토큰의 현재상태는 만료되지않았으며 아직 유효하다
+		assertFalse(tokenResult.token().isActivated()); // 토큰은 활성화되지 않았다.
+	}
+	@Order(2)
+	@Test
+	void 큐에없으며_이미_만료된_대기상태토큰을_가지고있을때_대기상태_토큰발급요청시_다시_대기상태의_토큰으로_전환된다() {
+		// given
+		// 큐에는 들어있지 않으며, 이미 만료된토큰을 가지고있다고 가정
+		sampleUserUUID = UUID.randomUUID();
+		Token token = Token.of(sampleUser, sampleUserUUID);
+		token.expire(LocalDateTime.now().minusSeconds(1)); // 이미 토큰은 만료되었음
+		tokenRepository.saveOrUpdate(token); // 영속성컨텍스트에 반영
+
+		// when
+		TokenResult.IssueWaitingToken tokenResult = tokenUsecase.issueWaitingToken(TokenCriteria.IssueWaitingToken.of(sampleUser.getId()));
+
+		// then
+		assertNotNull(tokenResult.token()); // 응답값의 토큰은 null이 아니다.
+		assertNotNull(tokenResult.user()); // 응답값의 유저는 null이 아니다.
+
+		assertEquals(sampleUser.getName(), tokenResult.token().getUser().getName()); // 응답값의 유저는 테스트유저이다.
+
+		assertEquals(1, tokenResult.position());// 대기열큐의 1번이다.
+		assertTrue(waitingQueue.contains(tokenResult.token().getUuid())); // 대기열큐에 uuid가 들어있음
+		assertEquals(TokenStatus.WAITING, tokenResult.token().getStatus());// 토큰의 현재상태는 대기상태이다.
+		assertFalse(tokenResult.token().isExpiredToken());// 토큰의 현재상태는 만료되지않았으며 아직 유효하다
+		assertFalse(tokenResult.token().isActivated()); // 토큰은 활성화되지 않았다.
+	}
+
+	/**
+	 * getWaitingTokenPositionAndActivateWaitingToken
+	 */
+	@Order(3)
+	@Test
+	void 대기토큰의_대기열큐의_대기순서번호가_1번이라면_활성화시킨후에_토큰상태를_응답한다() {
+		// given
+		long userId = sampleUser.getId();
+		// 토큰발급
+		TokenResult.IssueWaitingToken tokenResult = tokenUsecase.issueWaitingToken(
+			TokenCriteria.IssueWaitingToken.of(userId)
+		);
+		assertEquals(1, tokenResult.position()); // 대기열에 sampleUser의 토큰만 있으므로 대기순서는 1번이다.
+		assertEquals(TokenStatus.WAITING, tokenResult.token().getStatus()); // sampleUser의 토큰의 상태는 대기상태이다.
+		assertEquals(waitingQueue.peek(), tokenResult.token().getUuid()); // 대기큐의 맨앞의 uuid는 sampleUser 토큰의 uuid 이다
+		UUID uuid = tokenResult.token().getUuid();
+
+		// when
+		TokenResult.GetWaitingTokenPositionAndActivateWaitingToken result = tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
+			TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(uuid)
+		);
+
+		// then
+		assertEquals(TokenStatus.ACTIVE, result.status()); // 활성화상태이다.
+		assertFalse(waitingQueue.contains(result.uuid())); // 이미활성화된 토큰의 uuid는 대기열큐에 존재하지 않는다.
+		assertEquals(-1, result.position()); // 이미 대기열큐에서 dequeue 되어 활성화시켰으므로 대기번호는 의미없다.
+	}
+	@Order(4)
+	@Test
+	void 대기토큰의_대기열큐의_대기순서번호가_1번이_아니라면_토큰상태만_응답한다() {
+		// given
+		// 대기열의 순서가 firstUser.uuid -> sampleUser.uuid 순으로되어있어서
+		// firstUser의 대기번호는 대기열큐의 1번째 순서로 되어있음.
+		User firstUser = userRepository.save(User.of("다른유저"));
+		long firstUserId = firstUser.getId();
+		TokenResult.IssueWaitingToken firstUserTokenResult = tokenUsecase.issueWaitingToken(
+			TokenCriteria.IssueWaitingToken.of(firstUserId)
+		);
+		// sampleUser의 대기번호는 대기열큐의 2번째순서로 되어있음.
+		long sampleUserId = sampleUser.getId();
+		TokenResult.IssueWaitingToken sampleUserTokenResult = tokenUsecase.issueWaitingToken(
+			TokenCriteria.IssueWaitingToken.of(sampleUserId)
+		);
+		sampleUserUUID = sampleUserTokenResult.token().getUuid();
+		assertEquals(2, waitingQueue.getPosition(sampleUserUUID));
+
+		// when
+		TokenResult.GetWaitingTokenPositionAndActivateWaitingToken result = tokenUsecase.getWaitingTokenPositionAndActivateWaitingToken(
+			TokenCriteria.GetWaitingTokenPositionAndActivateWaitingToken.of(sampleUserUUID)
+		);
+		// then
+		assertEquals(TokenStatus.WAITING, result.status()); // 대기열큐의 대기순서가 2번째라면 아직 대기상태이다.
+		assertTrue(waitingQueue.contains(result.uuid())); // 이미활성화된 토큰의 uuid는 대기열큐에 존재한다
+		assertEquals(2, result.position()); // 대기열큐에 2번째에 위치한다
+
+	}
+}

--- a/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceIntegrationTest.java
@@ -169,7 +169,7 @@ public class ConcertServiceIntegrationTest {
 		);
 
 		// then
-		List<ConcertSeat> concertSeats = info.concertSeatList();
+		List<ConcertInfo.ConcertSeatListDto> concertSeats = info.concertSeatList();
 		assertEquals(50, concertSeats.size()); // 공연좌석 개수는 최대 50개이다.
 	}
 	@Order(6)

--- a/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -29,6 +30,7 @@ import io.hhplus.concert.TestcontainersConfiguration;
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
 import jakarta.persistence.EntityManager;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ContextConfiguration(classes = {

--- a/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceTest.java
@@ -121,8 +121,7 @@ public class ConcertServiceTest {
 		for(int i = 0 ; i < 50; i++) {
 			int number = i + 1;
 			long price = 1000 * ( i / 10 + 1);
-			boolean isAvailable = true;
-			if( number % 5 == 0) isAvailable = false; // 5의배수인 좌석번호는 예약불가능 상태
+			boolean isAvailable = number % 5 != 0; // 5의배수인 좌석번호는 예약불가능 상태
 
 			dbConcertSeats.add(ConcertSeat.of(concert, concertDate, number, price, isAvailable));
 		}

--- a/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/concert/ConcertServiceTest.java
@@ -1,5 +1,6 @@
 package io.hhplus.concert.domain.concert;
 
+import static io.hhplus.concert.domain.concert.ConcertService.*;
 import static io.hhplus.concert.interfaces.api.common.validators.PaginationValidator.*;
 import static io.hhplus.concert.interfaces.api.concert.ConcertErrorCode.*;
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
@@ -49,6 +50,7 @@ public class ConcertServiceTest {
 	private ObjectMapper objectMapper;
 
 	private static final String CONCERT_LIST_CACHE_KEY = "concert:list";
+	private static final String CONCERT_DATE_LIST_CACHE_KEY= "concert_date:list";
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/io/hhplus/concert/domain/payment/PaymentAndConfirmConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/payment/PaymentAndConfirmConcurrencyIntegrationTest.java
@@ -1,0 +1,178 @@
+package io.hhplus.concert.domain.payment;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDate;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import io.hhplus.concert.TestcontainersConfiguration;
+import io.hhplus.concert.application.usecase.payment.PaymentCriteria;
+import io.hhplus.concert.application.usecase.payment.PaymentResult;
+import io.hhplus.concert.application.usecase.payment.PaymentUsecase;
+import io.hhplus.concert.domain.concert.Concert;
+import io.hhplus.concert.domain.concert.ConcertDate;
+import io.hhplus.concert.domain.concert.ConcertDateRepository;
+import io.hhplus.concert.domain.concert.ConcertRepository;
+import io.hhplus.concert.domain.concert.ConcertSeat;
+import io.hhplus.concert.domain.concert.ConcertSeatRepository;
+import io.hhplus.concert.domain.reservation.Reservation;
+import io.hhplus.concert.domain.reservation.ReservationCommand;
+import io.hhplus.concert.domain.reservation.ReservationInfo;
+import io.hhplus.concert.domain.reservation.ReservationRepository;
+import io.hhplus.concert.domain.reservation.ReservationService;
+import io.hhplus.concert.domain.reservation.ReservationStatus;
+import io.hhplus.concert.domain.user.User;
+import io.hhplus.concert.domain.user.UserInfo;
+import io.hhplus.concert.domain.user.UserPoint;
+import io.hhplus.concert.domain.user.UserPointCommand;
+import io.hhplus.concert.domain.user.UserPointRepository;
+import io.hhplus.concert.domain.user.UserRepository;
+import io.hhplus.concert.domain.user.UserService;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Sql(statements = {
+	"SET FOREIGN_KEY_CHECKS=0",
+	"TRUNCATE TABLE payments",
+	"TRUNCATE TABLE reservations",
+	"TRUNCATE TABLE concert_seats",
+	"TRUNCATE TABLE concert_dates",
+	"TRUNCATE TABLE concerts",
+	"TRUNCATE TABLE user_point_histories",
+	"TRUNCATE TABLE user_points",
+	"TRUNCATE TABLE users",
+	"SET FOREIGN_KEY_CHECKS=1"
+}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class PaymentAndConfirmConcurrencyIntegrationTest {
+	@Autowired private PaymentUsecase paymentUsecase;
+	@Autowired private PaymentService paymentService;
+	@Autowired private ReservationService reservationService;
+	@Autowired private UserService userService;
+
+	@Autowired private PaymentRepository paymentRepository;
+	@Autowired private ReservationRepository reservationRepository;
+	@Autowired private UserRepository userRepository;
+	@Autowired private UserPointRepository userPointRepository;
+
+	@Autowired private ConcertRepository concertRepository;
+	@Autowired private ConcertDateRepository concertDateRepository;
+	@Autowired private ConcertSeatRepository concertSeatRepository;
+	private static final Logger log = LoggerFactory.getLogger(PaymentAndConfirmConcurrencyIntegrationTest.class);
+
+
+	/**
+	 * [동시성테스트] 동일한 회원이 여러개의 예약좌석 확정 및 결제를 동시에 진행한다.
+	 * (일정A, 좌석1번, 15000원), (일정B, 좌석11번, 10000원) => 둘다 임시예약상태(임시5분동안 좌석은 점유됨)
+	 * 여기서 공유자원은 무엇일까? => 회원의 포인트
+	 * - 좌석은 여러가지이고 상태값외로는 데이터변경자체가 없는편이다. 각 좌석은 낙관적락을 사용하고있고
+	 * - 포인트 충전/사용의 경우에는 비관적락(x-lock)을 사용함. 왜냐면 포인트는 의도적인 변경에 민감하며, 돈과 직결되므로 데이터의 정합성이 우선시함.
+	 */
+	User sampleUser;
+	UserPoint sampleUserPoint;
+
+	Concert sampleConcert1;
+	ConcertDate sampleConcertDate1;
+	ConcertSeat sampleConcertSeat1;
+
+	Concert sampleConcert2;
+	ConcertDate sampleConcertDate2;
+	ConcertSeat sampleConcertSeat2;
+
+	@BeforeEach
+	void setUp() {
+		// truncate -> setUp -> 테스트케이스 수행순으로 이뤄지고 있음.
+		// 유저 & 유저포인트 테스트 데이터 셋팅
+		sampleUser = User.of("최은강");
+		userRepository.save(sampleUser);
+		userPointRepository.save(UserPoint.of(sampleUser)); // 초기포인트 0 포인트
+
+		// 콘서트 테스트 데이터 셋팅
+		// 콘서트 1
+		sampleConcert1 = concertRepository.saveOrUpdate(Concert.create(
+			"테스트를 우선시하는 TDD 콘서트",
+			"TDD",
+			LocalDate.now(),
+			"서울시 성동구 연무장길",
+			10000
+		));
+		sampleConcertDate1 = sampleConcert1.getDates().get(0);
+		sampleConcertSeat1 = sampleConcertDate1.getSeats().get(0);
+
+		// 콘서트 2
+		sampleConcert2 = concertRepository.saveOrUpdate(Concert.create(
+			"통합테스트와 함께하는 TDD 콘서트",
+			"통합테스트",
+			LocalDate.now().plusWeeks(2),
+			"서울시 성동구 왕십리 광장",
+			5000
+		));
+		sampleConcertDate2 = sampleConcert2.getDates().get(0);
+		sampleConcertSeat2 = sampleConcertDate2.getSeats().get(0);
+	}
+	@Test
+	@Order(1)
+	@Sql(statements = {
+		"SET SESSION innodb_lock_wait_timeout=10"
+	}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+	@Sql(statements = {
+		"SET SESSION innodb_lock_wait_timeout=50"
+	}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+	void 회원이_동시에_여러개의_임시예약을_결제한다() throws ExecutionException, InterruptedException {
+		// given
+		long userId = sampleUser.getId();
+		// 먼저 2만원 충전
+		userService.chargePoint(UserPointCommand.ChargePoint.of(userId, 20_000L));
+
+		// 2개의 예약 셋팅
+		// 예약 1
+		ReservationInfo.TemporaryReserve temporaryReserveInfo1 = reservationService.temporaryReserve(ReservationCommand.TemporaryReserve.of(
+			sampleUser, sampleConcertSeat1
+		));
+		Reservation reservation1 = temporaryReserveInfo1.reservation();
+		long reservationId1 = reservation1.getId();
+		PaymentCriteria.PayAndConfirm paymentCriteria1 = PaymentCriteria.PayAndConfirm.of(userId, reservationId1);
+
+		// 예약 2
+		ReservationInfo.TemporaryReserve temporaryReserveInfo2 = reservationService.temporaryReserve(ReservationCommand.TemporaryReserve.of(
+			sampleUser, sampleConcertSeat2
+		));
+		Reservation reservation2 = temporaryReserveInfo2.reservation();
+		long reservationId2 = reservation2.getId();
+		PaymentCriteria.PayAndConfirm paymentCriteria2 = PaymentCriteria.PayAndConfirm.of(userId, reservationId2);
+
+		// when
+		// 결제 동시성테스트
+		CompletableFuture<PaymentResult.PayAndConfirm> future1 = CompletableFuture.supplyAsync(() -> paymentUsecase.payAndConfirm(paymentCriteria1));
+		CompletableFuture<PaymentResult.PayAndConfirm> future2 = CompletableFuture.supplyAsync(() -> paymentUsecase.payAndConfirm(paymentCriteria2));
+		CompletableFuture.allOf(future1, future2).join(); // 둘다 완료할 때까지 대기
+
+		PaymentResult.PayAndConfirm result1 = future1.get();
+		PaymentResult.PayAndConfirm result2 = future2.get();
+
+		// then
+		assertThat(result1.payment().getReservation()).isNotNull();
+		assertThat(result2.payment().getReservation()).isNotNull();
+
+		// 두개의 예약이모두 확정상태인지 확인
+		assertThat(result1.payment().getReservation().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		assertThat(result2.payment().getReservation().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+		// 포인트가 정상차감됐는지 확인: 20,000원 - (10,000원 + 5,000원) = 5,000원
+		UserInfo.GetUserPoint userPointInfo = userService.getUserPoint(UserPointCommand.GetUserPoint.of(userId));
+		assertThat(userPointInfo.userPoint().getPoint()).isEqualTo(5_000L);
+	}
+}

--- a/src/test/java/io/hhplus/concert/domain/payment/PaymentServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/payment/PaymentServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
@@ -31,6 +32,7 @@ import io.hhplus.concert.domain.user.UserRepository;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationEntityTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationEntityTest.java
@@ -7,6 +7,7 @@ import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -183,9 +184,9 @@ public class ReservationEntityTest {
 		assertNull(reservation.getReservedAt()); // 임시예약상태 - 예약확정일자 없음
 		assertEquals(true, reservation.isTemporary()); // 임시예약상태
 
-		// 임시예약상태로 6분간 sleep 한다
-		log.info("6분간 sleep 상태로 대기");
-		Thread.sleep(6 * 60 * 1000);
+		// 임시예약 기간이 만료된다
+		log.info("임시예약일자 만료");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 		assertTrue( DateValidator.isPastDateTime(reservation.getTempReservationExpiredAt()) );
 
 		// when

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceServiceTest.java
@@ -2,6 +2,7 @@ package io.hhplus.concert.domain.reservation;
 
 import io.hhplus.concert.domain.concert.Concert;
 import io.hhplus.concert.domain.concert.ConcertDate;
+import io.hhplus.concert.domain.concert.ConcertInfo;
 import io.hhplus.concert.domain.concert.ConcertSeat;
 import io.hhplus.concert.domain.concert.ConcertSeatRepository;
 import io.hhplus.concert.domain.user.User;
@@ -14,14 +15,21 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.hhplus.concert.domain.concert.ConcertService.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 public class ReservationMaintenanceServiceTest {
@@ -31,12 +39,21 @@ public class ReservationMaintenanceServiceTest {
     private ReservationRepository reservationRepository;
     @Mock
     private ConcertSeatRepository concertSeatRepository;
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+    @Mock
+    private ValueOperations<String, Object> valueOps;
+    @Mock
+    private ObjectMapper objectMapper;
+
 
     @BeforeEach
     void setUp() {
         reservationMaintenanceService = new ReservationMaintenanceService(
-                reservationRepository,
-                concertSeatRepository
+            reservationRepository,
+            concertSeatRepository,
+            redisTemplate,
+            objectMapper
         );
     }
     private static final Logger log = LoggerFactory.getLogger(ReservationMaintenanceServiceTest.class);
@@ -44,28 +61,36 @@ public class ReservationMaintenanceServiceTest {
     @Test
     void 임시예약날짜가_만료되면_예약상태는_취소상태로_변경되며_좌석도_예약가능으로_변경된다() throws InterruptedException {
         // given
+        long userId = 1L;
+        long concertId = 1L;
+        long concertDateId = 1L;
+        long concertSeatId = 1L;
+
         User user = User.of("예약자1");
         Concert concert = Concert.create("테스트콘서트", "아티스트명", LocalDate.now(), "콘서트장소", 2000);
         ConcertDate concertDate = concert.getDates().get(0);
         ConcertSeat concertSeat = concertDate.getSeats().get(0);
 
         Reservation reservation = Reservation.of(user,concert, concertDate, concertSeat);
-        // 임시에약상태로 변경
-        reservation.temporaryReserve();
-        // 임시예약상태를 만료
-        log.info("임시예약 유효기간이 만료됨");
-        reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
-
+        reservation.temporaryReserve(); // 임시에약상태로 변경
+        reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1)); // 임시예약상태를 만료
         List<Reservation> expiredReservations = List.of(reservation);
 
-        // 임시예약유효일자가 만료된 예약은 1개
-        when(reservationRepository.findExpiredTempReservations()).thenReturn(expiredReservations);
+        ReflectionTestUtils.setField(user, "id", userId); // user 아이디 수동설정
+        ReflectionTestUtils.setField(concert, "id", concertId); // concert 아이디 수동설정
+        ReflectionTestUtils.setField(concertDate, "id", concertDateId); // concertDate 아이디 수동설정
+        ReflectionTestUtils.setField(concertSeat, "id", concertSeatId); // concertSeat 아이디 수동설정
 
-        // updateCanceledExpiredTempReservations 메소드가 호출될 때 실제로 reservation 의 상태를 변경하도록 설정
+        when(reservationRepository.findExpiredTempReservations()).thenReturn(expiredReservations); // 임시예약유효일자가 만료된 예약은 1개
         doAnswer(invocation -> {
-            reservation.cancel(); // 직접 reservation 객체의 상태를 변경
+            reservation.cancel();
             return reservation;
-        }).when(reservationRepository).updateCanceledExpiredTempReservations();
+        }).when(reservationRepository).updateCanceledExpiredTempReservations(); // 예약상태를 '취소' 로 변경
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(concertSeatRepository.findConcertSeats(concertId, concertDateId)).thenReturn(
+          ConcertInfo.GetConcertSeatList.from(concertDate.getSeats())
+        );
 
         //when
         reservationMaintenanceService.cancel();
@@ -73,13 +98,15 @@ public class ReservationMaintenanceServiceTest {
         // then
         verify(reservationRepository, times(1)).updateCanceledExpiredTempReservations();
 
-        // 예약상태 확인
-        assertEquals(ReservationStatus.CANCELED, reservation.getStatus(), "취소상태이다");
-        assertFalse(reservation.isTemporary(), "임시예약상태가 아니다");
-        assertTrue(DateValidator.isPastDateTime(reservation.getTempReservationExpiredAt()), "임시예약만료일자가 이미 만료된상태다");
-        assertNull( reservation.getReservedAt(), "예약확정일은 없는상태다");
-        // 좌석상태 확인
-        assertTrue(reservation.getConcertSeat().isAvailable(), "예약이 가능하다");
+        assertEquals(ReservationStatus.CANCELED, reservation.getStatus(), "예약상태는 취소상태이다");
+        assertFalse(reservation.isTemporary(), "취소상태로 변경됐으므로 임시예약상태가 아니다");
+        assertTrue(DateValidator.isPastDateTime(reservation.getTempReservationExpiredAt()), "만료일자는 현재보다 이전이어야한다.");
+        assertNull( reservation.getReservedAt(), "예약확정일은 없어야한다");
+
+        assertTrue(reservation.getConcertSeat().isAvailable(), "좌석은 다시 예약이 가능하다");
+
+        String cacheKey = CONCERT_SEAT_LIST_CACHE_KEY + "-" + "concert_id:" + concertId +"-" + "concert_date_id:" + concertDateId;
+        verify(valueOps).set(eq(cacheKey), any(ConcertInfo.GetConcertSeatList.class), any());
     }
 
     @Test

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationMaintenanceServiceTest.java
@@ -50,9 +50,11 @@ public class ReservationMaintenanceServiceTest {
         ConcertSeat concertSeat = concertDate.getSeats().get(0);
 
         Reservation reservation = Reservation.of(user,concert, concertDate, concertSeat);
-        reservation.temporaryReserve();// 임시에약상태로 변경
-        log.info(":: 임시예약 만료가 될때까지 5분 대기");
-        Thread.sleep(5 * 60 * 1000 + 1);
+        // 임시에약상태로 변경
+        reservation.temporaryReserve();
+        // 임시예약상태를 만료
+        log.info("임시예약 유효기간이 만료됨");
+        reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 
         List<Reservation> expiredReservations = List.of(reservation);
 

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
@@ -36,6 +37,7 @@ import io.hhplus.concert.domain.user.UserRepository;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 import io.hhplus.concert.interfaces.api.common.InvalidValidationException;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -279,11 +280,12 @@ public class ReservationServiceIntegrationTest {
 		assertNotNull(reservation);
 		assertTrue(reservation.isTemporary()); // 임시예약상태
 		long reservationId = reservation.getId();
-		log.info("5분 + 1ms 대기");
-		Thread.sleep(TEMPORARY_RESERVATION_DURATION_MILLISECOND + 1);
 
 		log.info("임시예약이 만료됨");
-		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()));
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+		reservationRepository.saveOrUpdate(reservation);
+		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()), "만료일자는 이미 지나간 날짜임을 확인");
+
 		// when & then
 		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
 		BusinessException exception = assertThrows(
@@ -309,11 +311,12 @@ public class ReservationServiceIntegrationTest {
 		assertNotNull(reservation);
 		assertTrue(reservation.isTemporary()); // 임시예약상태
 		long reservationId = reservation.getId();
-		log.info("5분 + 1ms 대기");
-		Thread.sleep(TEMPORARY_RESERVATION_DURATION_MILLISECOND + 1);
 
 		log.info("임시예약이 만료됨");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+		reservationRepository.saveOrUpdate(reservation);
 		assertTrue(isPastDateTime(reservation.getTempReservationExpiredAt()));
+
 		// when & then
 		// 임시예약이 만료되어있는데 예약확정상태로 변경하려는 경우에 비즈니스규칙에 위배
 		ReservationInfo.Cancel cancelInfo = assertDoesNotThrow(

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceTest.java
@@ -1,5 +1,6 @@
 package io.hhplus.concert.domain.reservation;
 
+import static io.hhplus.concert.domain.concert.ConcertService.*;
 import static io.hhplus.concert.domain.reservation.ReservationStatus.*;
 import static io.hhplus.concert.interfaces.api.user.CommonErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -7,6 +8,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,9 +18,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.hhplus.concert.domain.concert.Concert;
 import io.hhplus.concert.domain.concert.ConcertDate;
+import io.hhplus.concert.domain.concert.ConcertInfo;
 import io.hhplus.concert.domain.concert.ConcertSeat;
 import io.hhplus.concert.domain.concert.ConcertSeatRepository;
 import io.hhplus.concert.domain.reservation.ReservationService;
@@ -37,10 +45,16 @@ public class ReservationServiceTest {
 	private ReservationRepository reservationRepository;
 	@Mock
 	private ConcertSeatRepository concertSeatRepository;
+	@Mock
+	private RedisTemplate<String, Object> redisTemplate;
+	@Mock
+	private ValueOperations<String, Object> valueOps;
+	@Mock
+	private ObjectMapper objectMapper;
 
 	@BeforeEach
 	void setUp() {
-		reservationService = new ReservationService(reservationRepository,concertSeatRepository);
+		reservationService = new ReservationService(reservationRepository,concertSeatRepository, redisTemplate, objectMapper);
 	}
 
 	private static final Logger log = LoggerFactory.getLogger(ReservationServiceTest.class);
@@ -48,6 +62,8 @@ public class ReservationServiceTest {
 	@Test
 	void 해당좌석에_대한_예약이력이_없는경우_임시예약을_신청한다() {
 		// given
+		when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
 		User user = User.of("테스트");
 		Concert concert = Concert.create("테스트 콘서트", "테스트 아티스트", LocalDate.now(), "테스트 장소", 15000);
 		ConcertDate concertDate = concert.getDates().get(0);
@@ -68,34 +84,46 @@ public class ReservationServiceTest {
 		assertFalse(concertSeat.isAvailable()); // 좌석은 이미 예약된 상태
 	}
 	@Test
-	void 해당좌석에_대한_예약이력이_만료상태일경우_임시예약으로_재신청할_수있다() throws InterruptedException {
+	void 예약이_취소상태일때_예약하려는좌석이_예약가능한상태라면_다시_예약할수있다() throws InterruptedException {
 		// given
+		long userId = 1L;
+		long concertId = 1L;
+		long concertDateId = 1L;
+		long concertSeatId = 1L;
+
 		User user = User.of("테스트");
 		Concert concert = Concert.create("테스트 콘서트", "테스트 아티스트", LocalDate.now(), "테스트 장소", 15000);
 		ConcertDate concertDate = concert.getDates().get(0);
 		ConcertSeat concertSeat = concertDate.getSeats().get(0);
-		assertTrue(concertSeat.isAvailable()); // 해당좌석은 예약가능
 
-		log.info("해당 좌석 임시예약 상태로 변경");
+		ReflectionTestUtils.setField(user, "id", userId); // user 아이디 수동설정
+		ReflectionTestUtils.setField(concert, "id", concertId); // concert 아이디 수동설정
+		ReflectionTestUtils.setField(concertDate, "id", concertDateId); // concertDate 아이디 수동설정
+		ReflectionTestUtils.setField(concertSeat, "id", concertSeatId); // concertSeat 아이디 수동설정
+
 		Reservation reservation = Reservation.of(user, concert, concertDate, concertSeat);
-		assertDoesNotThrow(()-> reservation.temporaryReserve());
-		assertTrue(reservation.isTemporary());
-
-		log.info("임시예약만료일자가 만료됨");
+		reservation.temporaryReserve();
 		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+		reservation.cancel();
 
-		log.info("임시예약이 만료되어 취소상태로 변경");
-		assertDoesNotThrow(() -> reservation.cancel()); // 임시예약상태로 변경
+		when(reservationRepository.findByConcertSeatIdAndUserId(userId, concertSeatId)).thenReturn(reservation);
+		when(concertSeatRepository.findConcertSeats(concertId, concertDateId)).thenReturn(
+			ConcertInfo.GetConcertSeatList.from(concertDate.getSeats())
+		);
 
-		when(reservationRepository.findByConcertSeatIdAndUserId(anyLong(), anyLong())).thenReturn(reservation);
+		String cacheKey = CONCERT_SEAT_LIST_CACHE_KEY + "-" + "concert_id:" + concertId +"-" + "concert_date_id:" + concertDateId;
+		when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
 		// when
-		log.info("when: 다시 임시예약 요청");
 		ReservationCommand.TemporaryReserve command = ReservationCommand.TemporaryReserve.of(user, concertSeat);
 		ReservationInfo.TemporaryReserve info = assertDoesNotThrow(() -> reservationService.temporaryReserve(command));
+
 		// then
 		assertTrue(info.reservation().isTemporary()); // 임시예약상태인지 확인
 		assertEquals(ReservationStatus.PENDING_PAYMENT, info.reservation().getStatus());
 		assertFalse(concertSeat.isAvailable()); // 좌석은 이미 예약된 상태
+
+		verify(valueOps).set(eq(cacheKey), any(ConcertInfo.GetConcertSeatList.class), any());
 	}
 	@Test
 	void 임시예약이_만료되면_예약취소상태로_변경할_수_있다() throws InterruptedException {

--- a/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/ReservationServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,9 +81,10 @@ public class ReservationServiceTest {
 		assertDoesNotThrow(()-> reservation.temporaryReserve());
 		assertTrue(reservation.isTemporary());
 
-		log.info("6분간 대기");
-		Thread.sleep(6 * 60* 1000); // 6분이 지나서 임시예약 유효기간이 만료
-		log.info("임시예약이 유효일자가 만료되어 취소상태로 변경");
+		log.info("임시예약만료일자가 만료됨");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
+
+		log.info("임시예약이 만료되어 취소상태로 변경");
 		assertDoesNotThrow(() -> reservation.cancel()); // 임시예약상태로 변경
 
 		when(reservationRepository.findByConcertSeatIdAndUserId(anyLong(), anyLong())).thenReturn(reservation);
@@ -110,8 +112,8 @@ public class ReservationServiceTest {
 		assertDoesNotThrow(()-> reservation.temporaryReserve());
 		assertTrue(reservation.isTemporary());
 
-		log.info("6분간 대기");
-		Thread.sleep(6 * 60* 1000); // 6분이 지나서 임시예약 유효기간이 만료
+		log.info("임시예약 유효기간 만료");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 
 		when( reservationRepository.findById( reservationId )).thenReturn(reservation);
 		// when
@@ -136,8 +138,8 @@ public class ReservationServiceTest {
 		assertDoesNotThrow(()-> reservation.temporaryReserve());
 		assertTrue(reservation.isTemporary());
 
-		log.info("6분간 대기");
-		Thread.sleep(6 * 60* 1000); // 6분이 지나서 임시예약 유효기간이 만료
+		log.info("임시예약 유효기간이 만료됨");
+		reservation.expireTemporaryReserve(LocalDateTime.now().minusSeconds(1));
 
 		log.info("임시예약이 유효일자가 만료되어 취소상태로 변경");
 		assertDoesNotThrow(() -> reservation.cancel()); // 임시예약상태로 변경

--- a/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
@@ -38,6 +38,8 @@ import io.hhplus.concert.domain.user.UserRepository;
 	"TRUNCATE TABLE concert_seats",
 	"TRUNCATE TABLE concert_dates",
 	"TRUNCATE TABLE concerts",
+	"TRUNCATE TABLE user_point_histories",
+	"TRUNCATE TABLE user_points",
 	"TRUNCATE TABLE users",
 	"SET FOREIGN_KEY_CHECKS=1"
 }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)

--- a/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/reservation/TemporaryReserveConcurrencyIntegrationTest.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
@@ -30,6 +31,7 @@ import io.hhplus.concert.domain.concert.ConcertSeatRepository;
 import io.hhplus.concert.domain.user.User;
 import io.hhplus.concert.domain.user.UserRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {

--- a/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import static io.hhplus.concert.interfaces.api.token.TokenErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -300,8 +301,11 @@ public class TokenServiceIntegrationTest {
 			TokenCommand.IssueWaitingToken.from(sampleUser)
 		);
 		Token token = tokenInfo.token();
-		log.info("만료여부를 확인하기 위해 6분 대기");
-		Thread.sleep(6 * 60 * 1000);
+		log.info("토큰 만료");
+		token.expire(LocalDateTime.now().minusSeconds(1));
+		tokenRepository.saveOrUpdate(token);
+
+
 		// when & then
 		BusinessException exception = assertThrows(
 			BusinessException.class,

--- a/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
@@ -94,6 +94,8 @@ public class TokenServiceIntegrationTest {
 		assertTrue(waitingQueue.contains(tokenUUID));
 		// 순서는 1번인가?
 		assertEquals(1, tokenInfo.position());
+		// 레디스에 토큰이 저장됐는가?
+		assertThat(redisTemplate.opsForValue().get(TOKEN_CACHE_KEY+token.getUuid())).isNotNull();
 	}
 	@Order(2)
 	@Test
@@ -148,12 +150,8 @@ public class TokenServiceIntegrationTest {
 			// 대기상태토큰 리스트에 추가
 			uuids.add(info.token().getUuid());
 		}
-		assertEquals(3, waitingQueue.size());
-		assertTrue(waitingQueue.contains(uuids.get(0)));
-		assertTrue(waitingQueue.contains(uuids.get(1)));
-		assertTrue(waitingQueue.contains(uuids.get(2)));
 
-		// when &then
+		// when & then
 		// 1번째 토큰
 		assertEquals(1, tokenService.getCurrentPosition(uuids.get(0)));
 		assertEquals(waitingQueue.peek(), uuids.get(0));

--- a/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/token/TokenServiceIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import io.hhplus.concert.TestcontainersConfiguration;
@@ -30,7 +31,7 @@ import io.hhplus.concert.domain.user.User;
 import io.hhplus.concert.domain.user.UserRepository;
 import io.hhplus.concert.interfaces.api.common.BusinessException;
 
-
+@ActiveProfiles("test")
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 @Sql(statements = {

--- a/src/test/java/io/hhplus/concert/domain/token/TokenServiceTest.java
+++ b/src/test/java/io/hhplus/concert/domain/token/TokenServiceTest.java
@@ -54,6 +54,10 @@ public class TokenServiceTest {
 		waitingQueue.clear();
 	}
 
+	/**
+	 * getCurrentPosition
+	 */
+	@Order(1)
 	@Test
 	void 대기큐에_요청_uuid가_존재하지않으면_BusinessException_예외발생() {
 		// given
@@ -68,6 +72,7 @@ public class TokenServiceTest {
 		assertEquals(UUID_NOT_FOUND.getMessage(), ex.getMessage());
 		assertEquals(UUID_NOT_FOUND.getHttpStatus(), ex.getHttpStatus());
 	}
+	@Order(2)
 	@Test
 	void 대기큐에_요청_uuid가_존재하면_대기번호_조회에_성공한다() {
 		// given
@@ -76,7 +81,7 @@ public class TokenServiceTest {
 		// when
 		int result = assertDoesNotThrow(() -> tokenService.getCurrentPosition(uuid));
 		// then
-		assertEquals(result, 2);
+		assertEquals(2, result);
 	}
 
 	/**

--- a/src/test/java/io/hhplus/concert/interfaces/api/UserE2EIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/interfaces/api/UserE2EIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +46,7 @@ import io.hhplus.concert.interfaces.api.user.PointResponse;
 import io.hhplus.concert.interfaces.api.user.UserRequest;
 import io.hhplus.concert.interfaces.api.user.UserResponse;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @Import(TestcontainersConfiguration.class)
@@ -167,6 +169,7 @@ public class UserE2EIntegrationTest {
 		// then
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 		assertEquals(0, response.getBody().getData().point());
+		assertEquals(0, response.getBody().getData().histories().size());
 	}
 	@Test
 	void 포인트_충전을_성공한다() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,8 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format-sql: true


### PR DESCRIPTION
## **연관 이슈**

- #38 
- #39 

---

## **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

> ### **[ step 11 ] 커밋링크** 

- 분산락 적용 계획


| 사용 기능 | 사용 분산락 | 사유 | TTL |
|:----------:|:-------:|:-----|:----:|
| 좌석 임시예약| 심플락 |  재시도횟수가 필요없으며, 동일한좌석에 대해 동시접근할때 1명을 제외한 나머지는 빠른실패를 비롯한 즉각적인 응답을 나타내야하기때문입니다. | 5분 |
| 포인트 사용 & 충전 | 스핀락 | 포인트(공유자원)에 대한 접근을 배타락으로 보호하여 동시요청이 오더라도 데이터정합성을 지키기위해서 동시에 충전/사용이 처리가 됩니다. <br>   동시에 접근을 차단해주며,  다시 시도하여 순차적으로 처리하여 데이터의 정합성까지 지키기위해서 스핀락을 사용하기로 했습니다. <br> 락을 점유할 수 있는 최대시간은 5초이며, 락 획득을 위해 다른 스레드가 기다릴 수 있는 최대시간은 5초입니다. 락을 얻기위해 다시 시도를 하기위한 시간은 100ms 로 설정했습니다. <br><br> - 락점유 최대시간: 5초 <br> - 다른 요청이 락을 획득하기까지 최대 대기시간:  5초 <br> - 락획득 재시도를 하기위한 대기시간: 100ms |  5초  |
 


**1. 임시좌석예약**
- 심플락  정의 & 임시예약서비스로직에 분산락적용
   - redis-template + SETNX 를 직접 사용한 직접 분산락을 구현: e1d8617
   - redisson 사용한 분산락 구현: ac2394d

**2. 포인트 사용 & 충전**
- 스핀락 정의 & 포인트 충전 & 사용 분산락 적용
  - redis-template 으로 스핀락 구현: 184aa68
  - redisson을 사용한 분산락 구현:  d46142c


<br><br>

> ### **[ step 12 ] 커밋링크**


| 사용 기능 | 선택전략 | 사유 | TTL |
|:----------:|:-------:|:-----|:--:|
| 콘서트목록 | 읽기전략 | 현재를 기준으로 예약가능한 목록리스트를 불러오기위함입니다.| 60분 |
| 콘서트일정 목록 | 읽기전략 |  현재를 기준으로 예약가능한 콘서트 일정목록을 나타내며 concertSeat, concert테이블을 조인하기때문입니다. | 30분 |
| 콘서트좌석목록| 읽기전략 | 좌석상태(예약확정, 임시예약, 예약가능)를 확인하기 위함입니다. <br> 상시변경가능성이 높기때문에 TTL고려가 필요  | 5분 |
| 토큰발급 |  쓰기전략 | 토큰상태 상관없이 토큰의 유효시간은 5분이기때문에 토큰의 유효성을 나타내기위함입니다 | 5분 |
| 좌석 임시예약 | 쓰기전략 | 좌석상태가 변경되기때문에 캐시저장소와 데이터베이스에 저장된 데이터가 일치하도록 정합성을 지켜야합니다. 예를들어 데이터의 정합성이 어긋나버리면 좌석이 이미 임시예약상태인데 클라이언트입장에서는 예약가능하다고하면 UX상에서도 불편함을 초래할 수 있기때문입니다. | 5분 |
| 좌석 임시예약 취소| 쓰기 전략 |  임시예약의 유효시간(5분)이 지났기때문에 스케줄러에 의해 취소처리가됩니다. 취소처리된 좌석은 다시 예약가능한상태이므로, 데이터의 정합성을 위해서 캐시저장소와 데이터베이스에서도 즉시 반영을 해야합니다.| 5분 |

**1. 콘서트 목록조회**
- redis-template 이용
- read-through 전략으로 읽기접근에 대한 캐싱 구현: a2a40df6
- 서비스 비즈니스로직 단위/통합 테스트코드 수정 및 리팩터링: 5d31c59b

**2. 콘서트 일정목록 조회**
- redis-template 이용
- read-through 전략으로 읽기접근에 대한 캐싱구현 및 관련 테스트코드 수정: ca5d676 -> 수정: 218f99a

**3. 특정날짜 콘서트 좌석 목록 조회**
- redis-template 이용
- read-through 전략으로 읽기접근에 대한 캐싱구현 및 관련 테스트코드 수정: 02c864d -> 수정: 218f99a
 
**4. 토큰 조회  / 토큰 검증 / 대기상태 토큰 발급 / 토큰활성화**
- redis-template 이용
- 4-1. uuid로 토큰정보조회
  -  읽기접근: read-through 전략
  - read-through 전략으로 읽기접근에 대한 캐싱구현 및 관련 테스트코드 수정: f8168e0
  
- 4-2. 대기상태 토큰발급
  - 쓰기접근: write-through 
  - write-through 전략으로 데이터정합성을 위한 데이터동기화 로직작성 및 관련 테스트코드 수정: 3971e90

이론으로는 캐시저장소에 저장후에 데이터베이스에 동기화를 해놓는다고 하고있지만, 실제로는 데이터베이스에 먼저 저장후, 캐시에 동기화를 시키는 편입니다. 만일 캐시저장소에 저장후 데이터베이스에 저장하게되면 캐시에서는 데이터의 식별자가 존재하지 않기때문에 나중에 상태정보를 수정으로 요청하는게 아닌, insert로 요청하게됩니다.

 
- 4-3. 토큰활성화
  - 읽기접근: read-through 전략으로 읽기접근에 대한 캐싱구현
  - 쓰기접근: write-through 전략으로 데이터베이스와 캐시스토어 정합성을 위한 데이터동기화
  - 읽기/쓰기 접근에 맞는 전략에 맞춰서 토큰활성화 로직 수정 및 관련테스트코드수정: 7f72d87

- 4-4. 토큰검증
  - 읽기접근: read-through 전략
  - read-through 전략으로 읽기접근에 대한 캐싱구현 및 관련 테스트코드 수정: 62793c2

**5. 좌석임시예약**
- 쓰기 접근: write-through 
- 데이터상태 변경이후에 데이터베이스에서 좌석목록데이터를 조회하여 캐시저장소에 즉시반영
- 관련커밋: ada3b5f

**6. 예약취소**
- 쓰기 접근: write-through 
- 데이터상태 변경이후에 데이터베이스에서 좌석목록데이터를 조회하여 캐시저장소에 즉시반영
- 관련커밋 및 테스트코드 수정: 03e0924

---

## **리뷰 포인트(질문)**

> ## [Step 11] 리뷰포인트
### [step11] 리뷰 포인트 1
지난5주차 리뷰포인트에서 말씀하신 "동일한 유저가 여러개의 임시예약을 동시에 결제하는 케이스를 추가"했으면 좋겠다는 피드백을 반영하여 해당 테스트케이스를 만들어서 작성해봤습니다.

- [예약 결제 유즈케이스로직](https://github.com/loveAlakazam/hh-08-concert/blob/step11/src/main/java/io/hhplus/concert/application/usecase/payment/PaymentUsecase.java#L46-L71)
- [같은유저의 여러개의 예약들을 동시에 결제요청할때 결제가 성공된다](https://github.com/loveAlakazam/hh-08-concert/blob/step11/src/test/java/io/hhplus/concert/application/usecase/payment/PaymentAndConfirmConcurrencyIntegrationTest.java#L81-L181)

저는 동시에 여러개의 예약을 결제 처리하니까, 포인트사용을 동시에 요청하는것과 비슷하므로 
**포인트를 공유자원으로한 동시성처리**라고 생각하여, 이 케이스에서도 포인트사용의 로직에도 배타락을 사용해서 동시성처리를 했으니
같은 유저가 동시에 여러개의 예약결제처리하는 케이스도 **비관적락(배타락)** 을 사용하면 된다고 생각했습니다.

배타락을 사용하게되면 다른트랜잭션의 읽기/쓰기 접근을 막기때문에, 락반환만 잘하면
동시에 결제요청하더라도(포인트사용을 요청하더라도) 데이터의 정합성을 지킬 수 있기때문입니다.

하지만 데이터베이스락인 배타락의 한계는 락을 획득한 트랜잭션이 락점유시간이 길어지게되어
다른 요청들은 락획득할때까지 기다리다가 타임아웃이 발생하여 결국 다른요청들은 처리하지 못하고 실패하는 현상이 발생합니다.

이러한 현상을 막고자 방어선인 레디스의 분산락을 사용하는거라고 생각을 했습니다.
동시요청이 들어와도 한개의 요청을 실행하고, 다른요청들은 락을 얻을 때까지 재시도가 가능하도록하여 포인트 데이터의 정합성을 지킬수 있도록 [유저포인트 사용에서 스핀락(redisson 사용)](https://github.com/loveAlakazam/hh-08-concert/blob/step12/src/main/java/io/hhplus/concert/domain/user/UserService.java#L54-L72)을 사용했습니다. 그래서 여러개의 예약들을 동시결제에는 따로 분산락을 적용하지 않았습니다.

코치님이 보셨을때 문제해결과 근거가 타당한지 솔직한 생각이 궁금합니다.

<br>

### [step11] 리뷰 포인트 2

분산락도 redis라는 nosql데이터베이스를 도입하는거라서, 비즈니스의 바깥에 위치한다고 판단하여 infrastructure 레이어에 지정했는데요. 클린레이어드에 위배되지않는지 확인해주시면 감사하겠습니다.
- [분산락 저장위치 - infrastructure](https://github.com/loveAlakazam/hh-08-concert/tree/step12/src/main/java/io/hhplus/concert/infrastructure/distributedlocks)

시나리오에 적용한 분산락 계획이 올바른지, 시나리오에 적용한 분산락 정의가 적합한지 확인해주시면 감사하겠습니다.


<br>

---

> ## [Step 12] 리뷰포인트

### [step12] 리뷰 포인트 1

목록조회와 관련된 서비스기능을 대상으로 read-through 를 적용했습니다. 

콘서트예약 서비스 시나리오에서는 아래 3개의 서비스가 read-through를 적용하기로 했습니다.

데이터의 변경이 자주없거나,  DB 테이블내 데이터의 로우개수가 많아질수록 DB로부터 데이터를 갖고오는데 오래걸리는 기능을 대상으로 read-through 읽기캐싱전략을 사용했습니다. 

- 콘서트목록
- 콘서트 일정목록
- 콘서트 좌석목록

이 3개의 서비스의 공통점은 모두 리스트로 반환을 한다는 것인데요.  저는 직렬화와 역직렬화에서 시행착오를 겪었고, 시행착오들을 되짚어보면 크게 2개로 추려지는데요.

**(1) 직렬화 시행착오 -  도메인 모델 엔티티간의 관계로 인해서 순환참조가 발생하여 직렬화가 되지 않은 오류**

```bash
org.springframework.data.redis.serializer.SerializationException: Could not write JSON: Document nesting depth (1001) exceeds the maximum allowed (1000, from StreamWriteConstraints.getMaxNestingDepth())
```

이 에러에 대한 이유는 JPA 엔티티의 순환참조문제이며, 부모엔티티(Concert)와 자식엔티티(ConcertDate, ConcertSeat 등) 엔티티가 서로 참조하게되어 무한반복되어 최대 깊이를 초과해버렸기 때문입니다.

그래서 엔티티내 서로 관계를 갖는 필드에 `@JsonManagedReference` ,`@JsonBackReference` , `@JsonIgnore` ,어노테이션을 부여했습니다.

- `@JsonManagedReference` : 부모엔티티가 자식엔티티를 참조 - 직렬화 할때 자식엔티티를 필요합니다.

  ```java
  // ConcertDate - 부모엔티티
  @Entity
  @Table(name = "concert_dates")
  public class ConcertDate extends BaseEntity {
  
  ...
  	
  	/* 콘서트날짜:콘서트좌석 = 1:N */
  	@OneToMany(mappedBy= "concertDate", cascade= CascadeType.ALL, orphanRemoval= true)
  	@JsonManagedReference("concertDate-seats") 
  	private List<ConcertSeat> seats = new ArrayList<>();
  
  ...
  }
  ```

- `@JsonBackReference` : 자식엔티티가  부모엔티티를 참조함 - 직렬화할때 부모엔티티를 필요 합니다.

  ```java
  // ConcertSeat - 자식엔티티
  @Entity
  @Table(name = "concert_seats")
  public class ConcertSeat extends BaseEntity {
  
  ...
  	
  	/* 콘서트좌석:콘서트날자 = N:1 */
  	@ManyToOne(fetch = FetchType.LAZY)
  	@JsonManagedReference("concertDate-seats")
  	@JoinColumn(name = "concert_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
  	@JsonBackReference("concert-seats")
  	private Concert concert;
  
  ...
  }
  ```

- `@JsonIgnore`

  - 직렬화/역직렬화에만 영향을 줍니다.

  - JPA의 연관관계나 쿼리실행에는 전혀 영향을 주지 않습니다. 
    ( 데이터베이스 조회, Join, Fetch Join 등과는 무관합니다.)

  - 직렬화할때 순환참조문제를 막기위해 불필요한 참조를 제외할수 있습니다.  부모엔티티는 자식엔티티참조를 무시하는데, 자식엔티티는 부모엔티티를 참조할 수 있습니다.

    ```java
    // Concert - 부모엔티티
    // 부모엔티티는 직렬화할때 자식엔티티를 참조하지 않습니다.
    
    @Entity
    @Table(name = "concerts")
    public class Concert extends BaseEntity {
    
    	/* 콘서트:콘서트좌석 = 1:N */
    	@OneToMany(mappedBy= "concert", cascade= CascadeType.ALL, orphanRemoval= true)
    	@JsonIgnore 
    	private List<ConcertSeat> seats = new ArrayList<>();
    
    }
    
    // ConcertDate - 자식엔티티
    // 자식엔티티가 부모엔티티가 필요할경우 부모엔티티를 참조합니다.
     
    @Entity
    @Table(name = "concert_dates")
    public class ConcertDate extends BaseEntity {
    
    ...
    	/* 콘서트날짜:콘서트 = N:1 */
    	@ManyToOne(fetch = FetchType.LAZY)
    	@JoinColumn(name ="concert_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
    	@JsonBackReference("concert-dates")
    	private Concert concert;
    	
    ...
    }
    ```

- 직렬화/역직렬화 할때 엔티티간의 참조관계 작성

  - 콘서트(Concert) 엔티티: [코멘트 링크](https://github.com/loveAlakazam/hh-08-concert/pull/41/files/5d31c59b9a55f7302e17842e16fcb4f414adf6ca#r2082241264)
  - 콘서트 일정(ConcertDate) 엔티티: [코멘트링크](https://github.com/loveAlakazam/hh-08-concert/pull/41/files#r2082260642)
  - 콘서트 좌석(ConcertSeat) 엔티티: [코멘트링크](https://github.com/loveAlakazam/hh-08-concert/pull/41/files#r2082274493)

원래 직렬화할때 어노테이션간의 필드를 꼭 붙이는걸 권장하는편인가요? 

실무에서는 엔티티도 많고 복잡할텐데,  복잡한 관계의 엔티티를 직렬화할때 제가 해결한 방법으로 해결하는편인가요? 제가 해결한 방법이 잘못이해하거나, 너무 복잡하게 해결했는지 등 코치님의 솔직한 생각이 궁금합니다.

<br>

**(2) 역직렬화 시행착오 -  캐시히트했을 때 캐시저장소에 있는데이터가 객체 변환(역직렬화)가 되지 않은 오류**

```bash
java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class ConcertInfo$GetConcertList
```

저는 이에 대한 해결책은 엔티티를 그대로 역직렬화하지말고, 엔티티 → DTO로 변환시켜서, DTO로 역직렬화시켜서 DTO 리스트로 응답하는 방식으로 역직렬화 문제를 해결했습니다. 

아래 링크를 누르시면 해당 코멘트로 이동됩니다.

- JPA 에서는 엔티티 리스트(List<Concert>)를 받음 → DTO 리스트로 변환시켜서 응답
  - 관련코드링크: [https://github.com/loveAlakazam/hh-08-concert/pull/41#discussion_r2072482492](https://github.com/loveAlakazam/hh-08-concert/pull/41#discussion_r2072482492)
- DTO 리스트로 역직렬화 과정
  - 관련코드링크: [https://github.com/loveAlakazam/hh-08-concert/pull/41#discussion_r2072479019](https://github.com/loveAlakazam/hh-08-concert/pull/41#discussion_r2072479019)

하지만 DTO로 정의를해보니까 코드가 많이 무거워보이고 가독성이 좋아보이지 않아보입니다…
실무에서도 역직렬화를 할때 DTO를 변환시켜서 하나요? 좀더 간편하게 직렬화/역직렬화를 할 수있는 방법이 있을까요? 
사실 간단한문제인데 제가 너무 복잡하게 해결한게 아닌가싶습니다. 너무 많이 낯설고, 복잡해서 해결하는데 시간이 오래걸리고 어려웠습니다 ㅠㅠ

<br>

### [step12] 리뷰 포인트 2

시나리오에 적용한 캐싱전략 계획이 적합한지, 문제가 없는지 확인해주시면 감사하겠습니다.
redisTemplate로 read-through/wirte-through 를 구현했는데 보완점이나 아니면 다른방법도 있는지 알려주시면 감사하겠습니다 :)

<br>


### **긴 장문의 리뷰포인트를 읽어주셔서 감사합니다** 🙇‍♀️ 

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

- 사전에 이론을 공부하고, 푹잘쉬고 잘잤다.


### Problem
<!--개선이 필요한 점-->

- 중간에 나태해진점도 있고, 문제해결에 방향을 잃은적도 있지만 그래도 포기하지않고 차근차근 이론부터 공부했다.
- 솔직히 너무 어려웠고, 처음해보는거라서 낯설어서 직접해보기까지 시간이 걸렸다. 정말 포기하고싶을정도로 정신적으로나 육체적으로나 지침
- 내가 테스트코드를 정말 어렵고, 가독성없게 짰다는걸 되돌아보게됨.

### Try
<!-- 새롭게 시도할 점 -->